### PR TITLE
Refactor timings iii

### DIFF
--- a/data/cards-food.cfg
+++ b/data/cards-food.cfg
@@ -418,14 +418,10 @@
 		school: "@eval FOOD",
 		rules: "Creatures Refresh and regain their full movement allowance.",
 		on_play: "def(class game game, class message.play_card info) ->commands [
-		  [ [creature.refresh(), set(creature.spaces_moved_this_turn, 0)]
+		  [creature.refresh(), set(creature.spaces_moved_this_turn, 0)]
 		  | creature <- game.creatures,
 		    not creature.is_building
-		  ],
 
-		  //TODO: make this card do something.
-		  //set(game.done_combat, false),
-		  set(game.precombat_phase, 0),
 		]",
 		
 	},

--- a/data/classes/bot.cfg
+++ b/data/classes/bot.cfg
@@ -106,11 +106,11 @@
 		friendly_constructs_in_lane: "def(class game game, int nlane) ->[class creature] filter(game.constructs, value.loc[0] = nlane and value.controller = game.current_player_index)",
 
 		is_phase_my_combat: "def(class game game) ->bool
-		  game.precombat_phase > 0 and
+		  not game.is_final_response and
 		  (game.nplayer = game.current_player_index)",
 
 		is_phase_their_combat: "def(class game game) ->bool
-		  game.precombat_phase > 0 and
+		  not game.is_final_response and
 		  (game.nplayer != game.current_player_index)",
 
 		is_phase_my_before_combat: "def(class game game) ->bool

--- a/data/classes/bot_evolutionary3.cfg
+++ b/data/classes/bot_evolutionary3.cfg
@@ -106,7 +106,7 @@
 	game_states_equal_timing: "def(class game a, class game b) ->bool
 		a.current_player_index = b.current_player_index and
 		a.nturn = b.nturn and
-		a.precombat_phase = b.precombat_phase and
+		a.is_final_response = b.is_final_response and
 		a.has_unresolved_combat = b.has_unresolved_combat and
 		a.in_response_phase = b.in_response_phase
 	",

--- a/data/classes/game.cfg
+++ b/data/classes/game.cfg
@@ -134,7 +134,6 @@
 		  def(class message.play_card msg)    play_card(msg),
 		  def(class message.play_ability msg) play_ability(msg),
 		  def(class message.end_turn msg)     handle_end_turn_message(msg.player_index),
-		  def(class message.movement msg)     movement(msg),
 		)",
 
 		has_unresolved_combat: "bool ::
@@ -496,20 +495,6 @@
 
 		   ]))
 		]",
-
-		movement: "def(null|class message info=null) ->commands
-		   [
-				   /*
-			 bind_command(do_moves),
-		     state_based_actions(),
-			 bind_command(do_endzone),
-		     state_based_actions(),
-			 */
-
-		      add(me.precombat_phase, 1),
-		      set(me.response_played, false)
-		   ]
-		",
 
 		combat: "def() ->commands [
 

--- a/data/classes/game.cfg
+++ b/data/classes/game.cfg
@@ -388,11 +388,11 @@
 
 
 		do_first_strike_attacks: "def()
-		   map(filter(creatures, ('First Strike' in value.abilities) and not value.is_exhausted),
+		   map(filter(creatures, ('First Strike' in value.abilities) and not (value.controller = current_player_turn_index and value.is_exhausted)),
 		       value.do_attack(me)
 		      )",
 		do_attacks: "def()
-		   map(filter(creatures, (not ('First Strike' in value.abilities)) and not value.is_exhausted),
+		   map(filter(creatures, (not ('First Strike' in value.abilities)) and not (value.controller = current_player_turn_index  and value.is_exhausted)),
 		       value.do_attack(me)
 		      )",
 

--- a/data/classes/game.cfg
+++ b/data/classes/game.cfg
@@ -462,6 +462,18 @@
 		[
 		  map(players, set(value.has_ended_turn, false)),
 
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['precombat_phase: ', me.precombat_phase,]),
+
 		  if(stack != [], [
 			set(me.stack, stack[0:size(stack)-1]),
 			bind_command(me.resolve, back(stack)),

--- a/data/classes/game.cfg
+++ b/data/classes/game.cfg
@@ -469,15 +469,13 @@
 			set(me.stack, stack[0:size(stack)-1]),
 			bind_command(me.resolve, back(stack)),
 		    ],
-		    if(response_played,
-			[set(me.response_played, false), set(me.is_final_response, false)],
-			if (is_final_response,
-				[
-					if(has_unresolved_combat, combat(), go_to_next_turn()),
-				],
-				[set(me.is_final_response, true)]
+		    if(not is_final_response,
+			[set(me.response_played, false), set(me.is_final_response, true)],
+			if(response_played,
+				[set(me.response_played, false), set(me.is_final_response, false)],
+				[if(has_unresolved_combat, combat(), go_to_next_turn())],
 			)
-		    ))
+		  ) )
 		]",
 
 		go_to_next_turn: "def() -> commands

--- a/data/classes/game.cfg
+++ b/data/classes/game.cfg
@@ -43,7 +43,7 @@
 		num_teams: "int :: 2",
 
 		current_player: "int <- current_player_index", // deprecated due to poor naming
-		current_player_index: "int <- if(current_choice != null, current_choice.player_index, (nturn + precombat_phase + size(stack) + (if(is_final_response, 1, 0)))%num_teams)",
+		current_player_index: "int <- if(current_choice != null, current_choice.player_index, (nturn + size(stack) + (if(is_final_response, 1, 0)))%num_teams)",
 		current_team_index: "team_index(current_player_index)",
 		current_player_turn_index: "int :: nturn%2",
 		player_obj: "class player <- players[current_player_index]",
@@ -64,14 +64,13 @@
 		nturn: { type: 'int', default: 0 },
 
 		turn: "int <- nturn",
-		precombat_phase: { variable: true, default: 0 },
 		response_played: { variable: true, default: false },
 		is_final_response: { variable: true, default: false },
 
 		stack: { variable: true, default: [], type: "[class message.play_card_base]" },
 		stack_id: { variable: true, default: 1 },
 
-		in_response_phase: "precombat_phase != 0 or stack != [] or is_final_response",
+		in_response_phase: "stack != [] or is_final_response",
 
 		log_message: "def(string msg) ->commands add(me.log, [msg])",
 		log: { default: [], type: '[string]' },
@@ -463,36 +462,20 @@
 		[
 		  map(players, set(value.has_ended_turn, false)),
 
-		  debug(['precombat_phase: ', me.precombat_phase,]),
-		  debug(['precombat_phase: ', me.precombat_phase,]),
-		  debug(['precombat_phase: ', me.precombat_phase,]),
-		  debug(['precombat_phase: ', me.precombat_phase,]),
-		  debug(['precombat_phase: ', me.precombat_phase,]),
-		  debug(['precombat_phase: ', me.precombat_phase,]),
-		  debug(['precombat_phase: ', me.precombat_phase,]),
-		  debug(['precombat_phase: ', me.precombat_phase,]),
-		  debug(['precombat_phase: ', me.precombat_phase,]),
-		  debug(['precombat_phase: ', me.precombat_phase,]),
-		  debug(['precombat_phase: ', me.precombat_phase,]),
+		  debug(['is_final_response: ', me.is_final_response,]),
+		  debug(['response_played: ', me.response_played,]),
 
 		  if(stack != [], [
 			set(me.stack, stack[0:size(stack)-1]),
 			bind_command(me.resolve, back(stack)),
 		    ],
 		    if(response_played,
-			[add(me.precombat_phase, 1), set(me.response_played, false), set(me.is_final_response, false)],
-			if (precombat_phase = 0,
-				if (is_final_response,
-					[
-						set(me.is_final_response, false),
-						if(has_unresolved_combat, combat(), go_to_next_turn())
-					],
-					[set(me.is_final_response, true)]
-				),
+			[set(me.response_played, false), set(me.is_final_response, false)],
+			if (is_final_response,
 				[
-					set(me.precombat_phase, 0),
-					set(me.is_final_response, false),
-				]
+					if(has_unresolved_combat, combat(), go_to_next_turn()),
+				],
+				[set(me.is_final_response, true)]
 			)
 		    ))
 		]",
@@ -514,8 +497,9 @@
 		   log_message(players[next_player].name + ', Turn ' + ((me.nturn+1)/num_teams+1)),
 			   
 		   add(me.nturn, 1),
-		   set(me.precombat_phase, 0),
 		   set(me.response_played, false),
+		   set(me.is_final_response, false),
+
 		   map(players_on_team((nturn+1)%num_teams), value.begin_turn(me)),
 		   map(me.permanents, if(value.controller = next_player, value.increment_summoning)),
 		   bind_command(do_begin_turn),
@@ -540,6 +524,8 @@
 		   bind_command(do_trampling),
 		   state_based_actions(),
 		   bind_command(do_endzone),
+
+		   set(me.is_final_response, false),
 		]
 		",
 

--- a/data/classes/game.cfg
+++ b/data/classes/game.cfg
@@ -43,7 +43,7 @@
 		num_teams: "int :: 2",
 
 		current_player: "int <- current_player_index", // deprecated due to poor naming
-		current_player_index: "int <- if(current_choice != null, current_choice.player_index, (nturn + precombat_phase + size(stack))%num_teams)",
+		current_player_index: "int <- if(current_choice != null, current_choice.player_index, (nturn + precombat_phase + size(stack) + (if(is_final_response, 1, 0)))%num_teams)",
 		current_team_index: "team_index(current_player_index)",
 		current_player_turn_index: "int :: nturn%2",
 		player_obj: "class player <- players[current_player_index]",
@@ -66,11 +66,12 @@
 		turn: "int <- nturn",
 		precombat_phase: { variable: true, default: 0 },
 		response_played: { variable: true, default: false },
+		is_final_response: { variable: true, default: false },
 
 		stack: { variable: true, default: [], type: "[class message.play_card_base]" },
 		stack_id: { variable: true, default: 1 },
 
-		in_response_phase: "precombat_phase != 0 or stack != []",
+		in_response_phase: "precombat_phase != 0 or stack != [] or is_final_response",
 
 		log_message: "def(string msg) ->commands add(me.log, [msg])",
 		log: { default: [], type: '[string]' },
@@ -477,11 +478,27 @@
 		  if(stack != [], [
 			set(me.stack, stack[0:size(stack)-1]),
 			bind_command(me.resolve, back(stack)),
-		   ],
-		   if(has_unresolved_combat or precombat_phase, if((response_played or precombat_phase = 0),
-				    [add(me.precombat_phase, 1), set(me.response_played, false)],
-				    [set(me.precombat_phase, 0), combat()]),
-		   [
+		    ],
+		    if(response_played,
+			[add(me.precombat_phase, 1), set(me.response_played, false), set(me.is_final_response, false)],
+			if (precombat_phase = 0,
+				if (is_final_response,
+					[
+						set(me.is_final_response, false),
+						if(has_unresolved_combat, combat(), go_to_next_turn())
+					],
+					[set(me.is_final_response, true)]
+				),
+				[
+					set(me.precombat_phase, 0),
+					set(me.is_final_response, false),
+				]
+			)
+		    ))
+		]",
+
+		go_to_next_turn: "def() -> commands
+		[
 		   set(me.animation_hints, []),
 		   add(me.animation_hints_id, 1),
 
@@ -504,8 +521,6 @@
 		   bind_command(do_begin_turn),
 
 		   state_based_actions(),
-
-		   ]))
 		]",
 
 		combat: "def() ->commands [

--- a/data/objects/citadel_controller.cfg
+++ b/data/objects/citadel_controller.cfg
@@ -2173,7 +2173,8 @@ on_do_update_game: "
 		),
 
 		if(is_new_turn or _state = null, spawn('turn_banner', 0, 0, {
-			_text: if(observer, game_state.players[game_state.current_player_turn_index].name + q('s Turn), if(is_your_turn, 'Your Turn', q(Opponent's Turn))),
+			_text: if(observer, game_state.players[game_state.current_player_turn_index].name + q('s Turn), if(xor, 'Your Turn', q(Opponent's Turn)))
+			where xor = if (game_state.in_response_phase, not is_your_turn, is_your_turn),
 			zorder: 4000,
 		})),
 

--- a/data/objects/citadel_controller.cfg
+++ b/data/objects/citadel_controller.cfg
@@ -783,7 +783,7 @@ properties: {
 	
 	mouse_enter_tile: "def(obj tile tile) ->commands [
 		if(_card_drag_play = null, set(tile.mouseover, true)),
-		debug(['mouse enter tile', tile.loc]),
+		//debug(['mouse enter tile', tile.loc]),
 		if(_playing_card != null, [
 			set_playing_card_arrows(_targets_chosen + if(tile.selectable, [tile.loc], [])),
 		]),
@@ -857,7 +857,7 @@ properties: {
 	   set(_discard_card_button, null),
 	   _set_mana_bar_using(0),
 
-	   debug(['BBB: CHOOSE TARGETS FOR CARD', card.card_type.name]),
+	   //debug(['BBB: CHOOSE TARGETS FOR CARD', card.card_type.name]),
 
 	   //choose targets for the card.
 	   choose_targets_for_card(card, [])
@@ -972,11 +972,11 @@ properties: {
 	
 	choose_targets_for_card: "def(obj card card, [Loc] current_targets) ->commands
 	[
-	debug(['BBB: CHOOSE_TARGETS_FOR_CARD', card.card_type.name]),
+	//debug(['BBB: CHOOSE_TARGETS_FOR_CARD', card.card_type.name]),
 	execute(me,
 	if(card_instance and state.in_response_phase and not card_instance.is_response,
 			[
-			debug(['BBB: RESPONSE_ONLY', card.card_type.name]),
+			//debug(['BBB: RESPONSE_ONLY', card.card_type.name]),
 	set_status_label('Can only cast response spells during response phase', 'red'),
 	],
 	[
@@ -985,7 +985,7 @@ properties: {
 		    if(can_afford and possible_targets != [] and not unique_violation,
 		      if(possible_targets = null,
 				([
-				debug('send cast'),
+				//debug('send cast'),
 				 send_move_message({
 				   type: 'moves',
 				   state_id: _processed_state_id,
@@ -1005,7 +1005,7 @@ properties: {
 				 [set(player.selectable, [-1, player.player_num] in possible_targets) | player <- level.chars, player is obj player_avatar],
 				 map(level.chars, if(value is obj tile, set(value.selectable, value.loc in possible_targets))),
 				 _spawn_tile_cursors(),
-				 debug(['BBB: SET PLAYING CARD', card.card_type.name]),
+				 //debug(['BBB: SET PLAYING CARD', card.card_type.name]),
 				 set(me._playing_card, card),
 				 set(_playing_ability, null),
 				 set(_targets_chosen, current_targets)
@@ -1405,7 +1405,7 @@ properties: {
 
 	_spawn_cards_in_player_hand_internal: "def(class player player, decimal left_side, decimal area, bool is_ally) ->commands
 	[
-	  debug(['SPAWN: ', size(player.hand), player.player_index, is_ally]),
+	  //debug(['SPAWN: ', size(player.hand), player.player_index, is_ally]),
 	  if(is_ally = false, set(_card_regions, [])),
 	  map(player.hand,
 	    
@@ -1514,7 +1514,7 @@ properties: {
 		   where player = value
 		   where prev_avatar = if(index < size(_avatars), _avatars[index])),
 
-		[debug(['HAVE PLAYER DAMAGE: ', hint.source.loc])  | hint <- state.animation_hints, hint is class animation.player_damage_hint],
+		//[debug(['HAVE PLAYER DAMAGE: ', hint.source.loc])  | hint <- state.animation_hints, hint is class animation.player_damage_hint],
 
 		map(state.players[:state.num_teams], spawn('life_bar', 0, 0, {
 			x: avatar_stats_left(player.player_index),
@@ -1824,7 +1824,7 @@ properties: {
 			game: state,
 		}, [
 			set(_choice_object, child),
-			debug('spawned choice'),
+			//debug('spawned choice'),
 		 ])))
     ]",
 
@@ -2216,7 +2216,7 @@ on_game_updated: "[
 		[
 			create_avatars(),
 
-			debug('game updated'),
+//			debug('game updated'),
 //			set(_deck_obj, deck_obj),
 			set(_hand_obj, hand_obj),
 			set(_level_obj, level_obj),
@@ -2328,7 +2328,7 @@ on_game_updated: "[
 			 if(card_rules, set(value.rules, card_rules))],
 	      
 		  //create a new object to represent this creature.
-		  [debug('SPAWN CREATURE: ' + value.name),
+		  [//debug('SPAWN CREATURE: ' + value.name),
 	      spawn('creature', 0, 0, {
 				  facing: 1,
 				  creature_object: value,
@@ -2481,12 +2481,13 @@ on_message_received: "[
 		  message.state), // end 'game' case.
 
          //default case.
-         [debug('got message: ', message)]) asserting message.type != 'invalid_session',
+//         [debug('got message: ', message)]) asserting message.type != 'invalid_session',
+         [null]) asserting message.type != 'invalid_session',
 		 fire_event('request_updates')]
 	 where message = map<- arg.message",
 
 on_request_updates: "if(client.in_flight = 0,
-					      [debug('request_updates: ' + _state_id), tbs_send(client, { type: 'request_updates', state_id: _state_id })])",
+					      [tbs_send(client, { type: 'request_updates', state_id: _state_id })])",
 on_connection_error: "[debug('message error', string<- arg.error), fire_event('request_updates')]",
 
 on_mouse_wheel: "

--- a/data/objects/end_turn_button.cfg
+++ b/data/objects/end_turn_button.cfg
@@ -73,7 +73,6 @@ properties: {
 },
 
 on_create: "[
-	debug(['RENDER BUTTON', _width, _height]),
 	render(_width, _height),
 	set(x, x),
 	set(y, y),


### PR DESCRIPTION
TODO: This seems to be working great now, the one thing I don't like is the following:

In many games vs AI, the game ends when the AI runs out of cards. Then your creatures march forwards to break the seals. Before this commit, on the turn when you would win by breaking the seals, you don't have to do anything because the creatures move on their own at the start of your turn. This is very smooth.

After this commit, if you have a response card playable in your hand, like a wisp, or if you have Hold Responses on, you still will have to press end turn once more than necessary, because you still get to respond to the AI's end of turn (when it cannot do anything). You have to do this, then you win immediately when your creatures move.

What I would like to do is to add a check, if this is the "respond to end of turn" phase, and after your creatures move, you would immediately win the game, then end your turn automatically.

I guess that it could be done by checking "for each creature, is it going to move to end zone / how much attack and how much is the seal" and add this up and check if it exceeds the other players life. Probably a more robust and preferable way is "copy the current game state, end the turn, do the moves, and see if the opponent is still alive" but I'm not sure how to code that at the moment.