### PR TITLE
change the end_of_turn sequence, to avoid repeatedly calling moves

### DIFF
--- a/data/classes/game.cfg
+++ b/data/classes/game.cfg
@@ -328,7 +328,7 @@
 		]",
 
 		state_based_actions_internal: "def() ->commands [
-		    set(me.creatures, new_creatures),
+			set(me.creatures, new_creatures),
 			set(me.constructs, new_constructs),
 			map(me.creatures, if((not value.alive) and (not value.obliterated), add(me.graveyard, {value.summon_id: value}))),
 			[ if(construct.card_name != null,
@@ -341,12 +341,13 @@
 			  bind_command(value.fire_events_on_death, me),
 			  bind_command(value.fire_event, 'on_die', [me])
 			])),
-		 if(new_creatures != me.creatures or new_constructs != me.constructs,
-		 [
-		 	bind_command(_calculate_resource_levels),
-		    bind_command(state_based_actions)
-		 ]
-		   )
+			if(new_creatures != me.creatures or new_constructs != me.constructs,
+				[
+					bind_command(_calculate_resource_levels),
+					bind_command(state_based_actions)
+				],
+				bind_command(state_based_moves)
+			),
 		]
 				 
 			where new_creatures = filter(me.creatures, value.alive)
@@ -363,7 +364,6 @@
 		   bind_command(apply_static_effects),
 		   bind_command(state_based_construct_destruction),
 		   bind_command(state_based_actions_internal),
-		   bind_command(state_based_moves),
 		 ]
 		",
 


### PR DESCRIPTION
"state_based_actions_interal" can sometimes recursively call
"state_based_actions". If this happens, it results in many
instances of the "do_moves" command seequence when the recursion
unwinds, since it will be called once at the tail of each call to
"state_based_actions".

After this commit, the moves sequence should only be called once.
Since repeated calls to it won't do anything, it shouldn't change
anything except make the control flow simpler.