### PR TITLE
add "taxes and tolls" (don't merge)

### DIFF
--- a/data/cards-gold.cfg
+++ b/data/cards-gold.cfg
@@ -373,7 +373,66 @@ When it is not your turn, Guard Post has 0 attack.",
 		on_play: "def(class game game, class message.play_card info) ->commands
 		  set(game.creature_at_loc_or_die(info.targets[0]).loc, info.targets[1])",
 	},
-	
+
+	"Taxes and Tolls": {
+		name: "Taxes and Tolls",
+		type: "invocation",
+		portrait: "school-gold.png",
+		school: "@eval GOLD",
+		cost: 0,
+		loyalty_cost: 2,
+		is_response: true,
+		rules: "Pay all your mana. Your opponent must pay the same amount of mana or their spell fizzles.",
+
+		possible_targets: "
+		  def(class game game, int nplayer, [Loc] targets) ->[Loc]|null
+		    if(game.stack = [] or not (game.stack[size(game.stack)-1] is class message.play_card), [], null)
+		",
+
+		on_play: "def(class game game, class message.play_card info) ->commands
+		if(info.choices,
+			[
+				// do whatever they chose
+				if (info.choices[0] = 0,
+					they_pay,
+					fizzle),
+				we_pay
+			]
+				asserting they_can_pay
+			,
+			if (they_can_pay,
+				game.set_current_choice({
+					card: me,
+					info: info,
+					player_index: 1 - info.player_index, // opponent of who played this card
+					text: 'Choose whether to pay X mana or to let your spell fizzle',
+					options: [
+							construct('choice.button', {
+								text: 'Pay',
+								tag: 0,
+							}),
+							construct('choice.button', {
+								text: 'Do not Pay',
+								tag: 1,
+							})
+						],
+				}),
+				// They can't afford to pay so skip the question
+				[
+					fizzle,
+					we_pay
+				]
+			)
+		)
+			asserting game.stack != []
+			where fizzle = set(their_spell.force_fizzle, true)
+			where we_pay = set(game.players[info.player_index].resources, 0)
+			where they_pay = add(game.players[their_spell.player_index].resources, -game.players[info.player_index].resources)
+			where they_can_pay = (game.players[their_spell.player_index].resources >= game.players[info.player_index].resources)
+			where their_spell = game.stack[size(game.stack) - 1]
+		",
+	},
+
 	"Bazaar": {
 		name: "Bazaar",
 		set: "core",


### PR DESCRIPTION
Tried to add this card, however it seems there is a bug in the citadel networking code. If a card prompts the *other* player to make a choice, it seems that player becomes unresponsive and disconnects from the server, while the first player immediately sees the result that they chose something, so the clients become out of sync.