### PR TITLE
Small interface tweaks

### DIFF
--- a/data/objects/card.cfg
+++ b/data/objects/card.cfg
@@ -111,8 +111,10 @@
 		if(is_choice and (choice_index is int),
 	       controller.option_clicked(choice_index, choice_value),
 	
-	       switch(mouse_button, 1, controller.card_clicked(me))
-	      )
+	       switch(mouse_button, 
+				1, controller.card_clicked(me),
+				3, controller.card_right_clicked(me),
+			null))
 	])
 			] where mouse_button = int<- arg.mouse_button",
 

--- a/data/objects/combo_controller.cfg
+++ b/data/objects/combo_controller.cfg
@@ -7,8 +7,8 @@
 	properties: {
 		items: { type: "[string]" },
 		_starting_selection_index: { type: "int", default: 0 },
-		_width: "int :: lib.citadel.px(200)",
-		_height: "int :: lib.citadel.py(50)",
+		_width: { type: "int", init: "lib.citadel.px(200)" },
+		_height:  { type: "int", init: "lib.citadel.py(50)" },
 
 		selected_index: "int<- _widget.selection",
 		_widget: "dropdown_widget<- widgets.combo",

--- a/data/objects/library_controller.cfg
+++ b/data/objects/library_controller.cfg
@@ -513,7 +513,7 @@
 
 			spawn('scrollable_pane', 0, 0, {
 			  x: level_width - px(300),
-			  y: px(28 + 72),
+			  y: px(28 + 90),
 			  area_width: px(290),
 			  area_height: py(500),
 			  left_align: false,
@@ -563,7 +563,7 @@
 
 			spawn('scrollable_pane', 0, 0, {
 			  x: level_width - px(300),
-			  y: px(28 + 72),
+			  y: px(28 + 90),
 			  area_width: px(290),
 			  area_height: py(500),
 			  left_align: false,

--- a/data/objects/title_multiplayer_controller.cfg
+++ b/data/objects/title_multiplayer_controller.cfg
@@ -80,16 +80,18 @@
 				]),
 			], [
 
-				spawn('combo_controller', level_width - lib.citadel.px(480), level_height - lib.citadel.py(80), {
+				spawn('combo_controller', level_width - lib.citadel.px(550), level_height - lib.citadel.py(80), {
 					items: ['Player vs Player', 'Co-op vs AI'],
+					_width: lib.citadel.px(280),
+					_height: lib.citadel.py(50),
 				}, [
 					set(_type_button, child)
 				]),
 
-				spawn('button_controller', level_width - lib.citadel.px(260), level_height - lib.citadel.py(80), {
+				spawn('button_controller', level_width - lib.citadel.px(240), level_height - lib.citadel.py(80), {
 					text: 'Play',
 					on_click: (def() -> commands fire_event(me, 'play_game')),
-					button_width: lib.citadel.px(240),
+					button_width: lib.citadel.px(220),
 					button_height: lib.citadel.py(50),
 				}, [
 					set(_go_button, child),


### PR DESCRIPTION
Enabled right-clicking on a card to remove it from deck.

Modified multiplayer mode button's size, so the "Players vs Players" text doesn't stretch out; 
Modified the position of the first deck entry, so it doesn't overlap with deck title;
