### PR TITLE
card property: "default_channeled_mana"

### DIFF
--- a/data/classes/card_base.cfg
+++ b/data/classes/card_base.cfg
@@ -26,6 +26,7 @@
 		is_player_ability: { variable: true, default: false, type: 'bool' },
 
 		is_channeled: { variable: true, default: false, type: 'bool' },
+		default_channeled_mana: { variable: true, default: 0, type: "int" },
 
 		flavor_text: { type: "string|null", variable: true },
 

--- a/data/objects/citadel_controller.cfg
+++ b/data/objects/citadel_controller.cfg
@@ -349,8 +349,9 @@ properties: {
 
 			set(_amount_channeled, amount_channeled),
 
-		] where amount_channeled = state.players[state.nplayer].resources - state.players[state.nplayer].calculate_cost(card.card_type)
-	)
+		] where amount_channeled = if( card.card_type.default_channeled_mana > 0 and card.card_type.default_channeled_mana< max_channel, card.card_type.default_channeled_mana , max_channel)
+		  where max_channel = (state.players[state.nplayer].resources - state.players[state.nplayer].calculate_cost(card.card_type))
+		)
 	]",
 
 	_spawn_channeling_label: "def(int amount) ->commands [


### PR DESCRIPTION
Added a property of "default_channeled_mana", which can be set to define
the max mana a card would default channel. Mainly used to let
upper-limited channeling effects more friendly to use.