### PR TITLE
Support for player.this_turn_effect

### DIFF
--- a/data/classes/player.cfg
+++ b/data/classes/player.cfg
@@ -94,8 +94,12 @@
 			map(filter(game.permanents, value.controller = player_index and value.income > 0), gain_mana_hint(game, value.loc)),
 		]",
 		end_turn: "def(class game game) ->commands [
-			add(base_income, if(base_income <= 1, 3, 1)),
-		]",
+			map(this_turn_effects, add(me[value.attr], -value.delta)),
+			map(this_turn_effects_compensate, add(me[value.attr], value.delta)),
+			set(me.this_turn_effects, []),
+			set(me.this_turn_effects_compensate, []),
+			add(base_income, if(base_income <= 1, 3, 1)),			// 0 mana mulligan round
+		] where the_player = game.players[game.current_player]",
 
 		no_cards_to_draw: "size(deck) + size(discard_pile) = 0",
 
@@ -192,15 +196,23 @@
 		apply_static_effect: "def(function(class player, map) ->commands apply, function(class player, map) ->commands revert, map info, int duration=DURATION_STATIC) ->commands [
 			add_static_effect(construct('static_effect', {apply_fn: apply, revert_fn: revert, info: info, duration: duration}))
 		]",
+		
+		apply_effect_until_end_of_turn: "def(string attr, int delta) ->commands [
+			add(me[attr], delta),
+			add(me.this_turn_effects, [{attr: attr, delta: -delta}])
+		]",
 
 		static_effects: { default: [], type: '[class static_effect]' },
+		this_turn_effects: { default: [], type: '[map]'},
+		this_turn_effects_compensate: { default: [], type: '[map]'},
 
 		xp_level: { default: '@eval {1:0,2:0,3:0,4:0,5:0}', type: '{int -> int}' },
 		xp_needed: { default: '@eval {1:1,2:1,3:1,4:1,5:1}', type: '{int -> int}' },
 		resource_level: { default: '@eval {1:0,2:0,3:0,4:0,5:0}', type: '{int -> int}' },
+		base_resource_level: { variable: true, default: '@eval {1:0,2:0,3:0,4:0,5:0}', type: '{int -> int}' },
 		get_resource_level: "def(int nresource) ->int resource_level[nresource] or 0",
 		calculate_resource_levels: "def(class game game) ->commands
-			set(resource_level, fold(map(range(5), {(resource): count(game.permanents, value.controller = player_index and find(value.school, value = resource) != null)} where resource = value+1), a+b, {}))
+			set(resource_level, fold(map(range(5), {(resource): count(game.permanents, value.controller = player_index and find(value.school, value = resource) != null) +base_resource_level[resource]} where resource = value+1), a+b, {}))
 		",
 
 		resources: { variable: true, default: 3, type: 'int',


### PR DESCRIPTION
added the support for player.apply_effect_until_end_of_turn

player.this_turn_effects is the same as creature.this_turn_effects

and player.this_turn_effects_compensate is added to support operating on
lists, because you can't add(var, -{list}) with FFL.

also, a property of base_resource_level, which is used by one of my
cards that temporally adjust a player's school levels.