### PR TITLE
3 Rival Decks

### DIFF
--- a/data/classes/rival_decks.cfg
+++ b/data/classes/rival_decks.cfg
@@ -10,9 +10,12 @@
 	",
 
 	decks: "{string->[string]} :: query_cache(global_cache(1), null, {
-		q(Anthem of Battle): [q(Loyal Guard),q(Mercenary)]*5 + [q(Anthem of Battle), q(Mine),q(Man-at-Arms), q(Thunderer), q(Guard Post), q(King's Rider)]*3 + [q(Highlands), q(Testudo), q(Wall of Stone),q(Oldric's Trap)]*2  + [q(Oldric, Lord of the Hold)],
+		q(Catherine Materia): [q(Loyal Guard),q(Mercenary)]*5 + [q(Infantry Support)]*3 + [q(Anthem of Battle), q(Mine),q(Man-at-Arms), q(Thunderer), q(Guard Post), q(King's Rider),q(Shield Bearer),q(Eager Swordsman)]*3 + [q(Highlands), q(Testudo), q(Wall of Stone),q(Oldric, Lord of the Hold),q(Desperate Evasion)]*2  + [q(Warrior Elite),q(Tactical Maneuver),q(Oldric's Trap)],
 
-		q(Meira AetherMinerva): [q(Blessing of Endurance), q(Weakness), q(Ilz Apprentice), q(Acolyte), q(Cunning Wisp), q(Disciple), q(Library), q(Rihn's Anointed), q(Temple Guard), q(Dawn Obelisk), q(High Guard), q(Inquisitor)]*3 + [q(Divine Restoration), q(Acolyte), q(Fireball), q(Polymorph), q(Spirit of Intellect)]*2  + [q(Tactical Blunder), q(Shrine of the Martyr), q(Rokh)],
-	})
+		q(Meira AetherMinerva): [q(Blessing of Endurance), q(Weakness), q(Ilz Apprentice), q(Acolyte), q(Cunning Wisp), q(Disciple), q(Library), q(Rihn's Anointed), q(Temple Guard), q(Dawn Obelisk), q(High Guard), q(Inquisitor)]*3 + [q(Divine Restoration), q(Acolyte), q(Fireball), q(Polymorph), q(Spirit of Intellect), q(Rokh)]*2  + [q(Tactical Blunder), q(Shrine of the Martyr)],
+
+		q(Grizzis Gaea): [q(Darkwood Denizen),q(Wolf Rider)]*4 + [q(Savage Wolf),q(Direwolf),q(Guardian Tracker),q(Guardian Tunneler),q(Guardian Herald)]*3 + [q(If-Uluk, the Swift),q(Hunting Grounds),q(Cover),q(Nature's Blessing),q(Furious Rampage),q(Outsmart the Guards),q(Green Adder),q(Treant Sapling),q(Guardian King)]*2 + [q(Forest),q(Greater Wurm),q(Savage Lands),q(Relentless Behemoth),q(Cave Troll),q(Quillboar),q(Purrsan Ambusher),q(Intense Warfare),q(Battlecry)]
+		
+})
 	",
 }

--- a/data/rivals.cfg
+++ b/data/rivals.cfg
@@ -11,7 +11,7 @@
 		text: "Wandering mercenaries are a common sight among the iron cities. They make for bloodthirsty adversaries.",
         set: "core",
 		bot_args: {
-			deck: "[string] :: lib.rival_decks.get_deck(choose(['Prosperous Empire', 'Prosperous Empire', 'Stone and Scrolls']))",
+			deck: "[string] :: lib.rival_decks.get_deck(choose(['Catherine Materia', 'Prosperous Empire', 'Stone and Scrolls']))",
 		},
 		portrait: "janus-the-great.png",
 		portrait_scale: 0.2,
@@ -23,6 +23,8 @@
 	],
 
 	},
+	
+	
 
 	{
 		name: "Gezzix",
@@ -102,7 +104,7 @@
         set: "core",
 
 		bot_args: {
-			deck: "[string] :: lib.rival_decks.get_deck(choose([q(Gaea's Revenge)]))",
+			deck: "[string] :: lib.rival_decks.get_deck(choose([q(Gaea's Revenge),q(Grizzis Gaea)]))",
 		},
 		portrait: "grizzis-lord-of-the-hunt.png",
         portrait_scale: 0.2,


### PR DESCRIPTION
Catherine Materia, Meira AetherMinerva and Grizzis Gaea.
The 3 decks all have 50 cards now, and they're easier for AI to use
well.