### PR TITLE
Buff Treant Sapling to 2/3

### DIFF
--- a/data/cards-food.cfg
+++ b/data/cards-food.cfg
@@ -502,7 +502,7 @@
 			sound_death: "creatures/death-troll.wav",
 			sound_attack: "creatures/attack-troll.wav",
 			attack: 2,
-			life: 2,
+			life: 3,
 			triggered_abilities: [{
 				name: "Growth",
 				rules: "Gets +1/+1 at start of your turn.",


### PR DESCRIPTION
Buff Treant Sapling's health by 1, so it's no longer an inferior version
of Wolf Rider.