### PR TITLE
Modified Rival Decks

### DIFF
--- a/data/classes/rival_decks.cfg
+++ b/data/classes/rival_decks.cfg
@@ -10,11 +10,11 @@
 	",
 
 	decks: "{string->[string]} :: query_cache(global_cache(1), null, {
-		q(Catherine Materia): [q(Loyal Guard),q(Mercenary)]*5 + [q(Infantry Support)]*3 + [q(Anthem of Battle), q(Mine),q(Man-at-Arms), q(Thunderer), q(Guard Post), q(King's Rider),q(Shield Bearer),q(Eager Swordsman)]*3 + [q(Highlands), q(Testudo), q(Wall of Stone),q(Oldric, Lord of the Hold),q(Desperate Evasion)]*2  + [q(Warrior Elite),q(Tactical Maneuver),q(Oldric's Trap)],
+		q(Catherine Materia): [q(Loyal Guard),q(Mercenary)]*5 + [q(Infantry Support)]*3 + [q(Anthem of Battle), q(Mine),q(Man-at-Arms), q(Guard Post), q(King's Rider),q(Shield Bearer),q(Eager Swordsman)]*3 + [q(Highlands), q(Testudo), q(Wall of Stone),q(Oldric, Lord of the Hold),q(Desperate Evasion),q(Warrior Elite),q(Deephelm Explorer)]*2  + [q(Tactical Maneuver),q(Oldric's Trap)],
 
 		q(Meira AetherMinerva): [q(Blessing of Endurance), q(Weakness), q(Ilz Apprentice), q(Acolyte), q(Cunning Wisp), q(Disciple), q(Library), q(Rihn's Anointed), q(Temple Guard), q(Dawn Obelisk), q(High Guard), q(Inquisitor)]*3 + [q(Divine Restoration), q(Acolyte), q(Fireball), q(Polymorph), q(Spirit of Intellect), q(Rokh)]*2  + [q(Tactical Blunder), q(Shrine of the Martyr)],
 
-		q(Meira AetherMateria): [q(Disciple),q(Rihn's Martyr),q(Rihn's Anointed),q(Shield Bearer),q(Temple Guard),q(Dawn Obelisk),q(Loyal Guard)]*3 + [q(Eager Swordsman),q(Weakness),q(Oil of Anointing),q(Infantry Support),q(Mine),q(Tulnun Friar),q(Anthem of Battle),q(Rider of the Thorn),q(Inquisitor),q(Rokh)]*2 + [q(Warrior Elite),q(Thunderer),q(Tree of Life),q(Smite the Defilers),q(Prayer of the Valorous),q(Desperate Evasion),q(Blessing of Endurance),q(Blessed Lance),q(Divine Restoration)],
+		q(Meira AetherMateria): [q(Disciple),q(Rihn's Martyr),q(Rihn's Anointed),q(Shield Bearer),q(Temple Guard),q(Dawn Obelisk),q(Loyal Guard)]*3 + [q(Eager Swordsman),q(Weakness),q(Oil of Anointing),q(Infantry Support),q(Mine),q(Tulnun Friar),q(Anthem of Battle),q(Rider of the Thorn),q(Inquisitor),q(Rokh)]*2 + [q(Warrior Elite),q(Deephelm Explorer),q(Tree of Life),q(Smite the Defilers),q(Prayer of the Valorous),q(Desperate Evasion),q(Blessing of Endurance),q(Blessed Lance),q(Divine Restoration)],
 		
 		q(Gezzix AetherEntropia) : [q(Hypothermia),q(Disciple),q(Skeletal Parasite),q(Soothsayer),q(Skeleton),q(Duskwind Obelisk),q(Nightblade),q(Dark Emissary),q(Tulnun Friar)]*3 + [q(Dwarvish Fiend),q(Grave Stalker),q(High Guard),q(Vampire),q(Knife in the Dark),q(Diseased Corpse),q(Dawn Obelisk)]*2 + [q(Rokh),q(Doomsday Crypt),q(Rider of the Thorn),q(Radiant Guardian),q(Tree of Life),q(Flesh Golem),q(Blessed Lance),q(Blessing of Endurance),q(Obliterate)],
 		


### PR DESCRIPTION
removed Thunderers, since AI doesn't understand Reload.