### PR TITLE
improve deck UI

### DIFF
--- a/data/objects/deck_preview_widget.cfg
+++ b/data/objects/deck_preview_widget.cfg
@@ -26,12 +26,20 @@
 				_text: q(<font size='24'>) + deck.name + q(</font>\n) +
 				q(<font size='18'>) +
 				fold(map(range(1,6), if(quantity > 0, q(<img src='images/icons/school-) + (string<- SCHOOL_NAMES[value]) + q(.svg'></img> ) + str(quantity) + q( ), '') where quantity = count(cards, context.value in value.school_list)), a+b, '') +
+				q(\n) +
+				fold(map(['creature','spell','land'], if(quantity_type > 0, q(<img src='images/icons/type-) + (string<-value) + q(.svg'></img> ) + str(quantity_type) + q( ), '') 
+				where quantity_type = if(value='creature', count(cards, value.type = 'creature' and value.is_land=false),
+						value='spell', count(cards, value.type = 'spell'),
+						value='land', count(cards, value.type = 'creature' and value.is_land=true),
+						0)
+				), a+b, '') +
 				q(</font>) +
 				q(<font size='14'>\n) +
 				if(deck.notes, deck.notes, '') +
 				q(</font>),
 				zorder: zorder,
-			}),
+			})  
+			,
 
 			if(edit_deck_label,
 			spawn('button_controller', 0, 0, {

--- a/data/objects/library_archive_controller.cfg
+++ b/data/objects/library_archive_controller.cfg
@@ -26,7 +26,7 @@
 				mid_y: avi.y + lib.citadel.py(32),
 				button_width: lib.citadel.py(24),
 				button_height: lib.citadel.py(24),
-				on_click: (def()->commands controller.remove_deck(find(level.chars, value is obj library_deck_summary and value.deck_name = deck.name), deck.name)),
+				on_click: (def()->commands controller.remove_deck_prompt(find(level.chars, value is obj library_deck_summary and value.deck_name = deck.name), deck.name)),
 				use_absolute_screen_coordinates: true,
 				color_scheme: lib.citadel.library_color_scheme,
 			}, [

--- a/data/objects/library_controller.cfg
+++ b/data/objects/library_controller.cfg
@@ -833,7 +833,8 @@
 			set(_deck_summary.avatar_override, card.name); _deck_summary.show_avatar()
 		),
 
-		if(entry != null and entry.count < deck_rules.max_duplicates and entry.count < count(account_info.collection, value.name = card.name),
+		if(entry != null and entry.count < deck_rules.max_duplicates and entry.count < count(account_info.collection, value.name = card.name) and (deck_rules.max_cards = null or num_cards < deck_rules.max_cards),
+
 		[
 			(add(entry.count, 1); [entry.render_entry(), view.update_card_quantity(card.name)]),
 			entry.pulse(),
@@ -865,7 +866,7 @@
 			count: 1,
 			controller: me,
 		})
-		)
+		) where num_cards = sum(map(deck, value.count))
 		]
 		where entry = find(deck, value.card.name = card.name)
 		",


### PR DESCRIPTION
1. A prompt before deleting vault decks;
2. Prevent adding cards to a 50-card deck by clicking on a deck entry. 
3. Preview in deck selection shows the number of cards in each type.