### PR TITLE
Fixup Hypothermia effect positioning

### DIFF
--- a/data/objects/effects/hypothermia_creature_effect.cfg
+++ b/data/objects/effects/hypothermia_creature_effect.cfg
@@ -42,18 +42,8 @@
 
 	on_create: "[
 		set(animation, 'effect'),
-		add(y, lib.citadel.py(90)),
+		add(y, lib.citadel.py(25)),
 
-		if(creature.creature_object.controller != controller.state.nplayer,
-		[
-			set(rotate, 180),
-			add(y, lib.citadel.py(60)),
-		],
-		[
-			set(rotate, 0),
-			add(y, -lib.citadel.py(60)),
-		]
-		),
 		set(scale, 0.17*tile_height/140.0) where tile_height = if(tile, tile.hex_height, lib.citadel.py(128)) where tile = find(level.chars, value is obj tile)
 	]",
 


### PR DESCRIPTION
It was being incorrectly shown for enemy creatures.