### PR TITLE
Allow impact_effect_base to effect player_avatar objects

### DIFF
--- a/data/object_prototypes/impact_effect_base.cfg
+++ b/data/object_prototypes/impact_effect_base.cfg
@@ -3,7 +3,7 @@
 	is_strict: true,
 
 	properties: {
-		targets: { type: "[obj tile]" },
+		targets: { type: "[obj tile|obj player_avatar]" },
 
 		target_creature: { type: "null|obj creature" },
 


### PR DESCRIPTION
This fixes a crash when casting cards such as Fireball on a player.