### PR TITLE
Possible error while silencing `Guardian Tunneler`?

### DIFF
--- a/data/test-cases.cfg
+++ b/data/test-cases.cfg
@@ -578,6 +578,86 @@
 	],
 },
 
+//   Rationale
+//
+//   When this playable test was added, silencing an unengaged 'Guardian
+// Tunneler' would result in it (maybe unintendedly) ending with -4
+// armor (instead of no armor bonus).
+{
+	name: 'correct_silence_ordering',
+	text: '',
+	set: 'core',
+	avatar: 'guardian-sapper.png',
+	portrait: 'guardian-sapper.png',
+	portrait_scale: 0.2,
+	portrait_translate: [10, 20],
+	enemy_name: 'Gwenneg',
+	skip_mulligan: true,
+	player_resources: 20,
+	player_deck: [
+		'Silence'
+		, 'Silence'
+		, 'Testudo'
+		, 'Anthem of Battle'
+	],
+	bot_args: {
+		deck: "['Guardian Tunneler'] * 20",
+	},
+
+	starting_units: [
+		{
+			card_name: 'Guardian Tunneler',
+			loc: [0, 1],
+			controller: 0,
+		},
+		{
+			card_name: 'Guardian Tunneler',
+			loc: [1, 0],
+			controller: 0,
+		},
+		{
+			card_name: 'Guardian Tunneler',
+			loc: [2, 0],
+			controller: 0,
+		},
+		{
+			card_name: 'Guardian Tunneler',
+			loc: [3, 0],
+			controller: 0,
+		},
+		{
+			card_name: 'Diseased Corpse',
+			loc: [4, 1],
+			controller: 0,
+		},
+		{
+			card_name: 'Guardian Tunneler',
+			loc: [0, 3],
+			controller: 1,
+		},
+		{
+			card_name: 'Guardian Tunneler',
+			loc: [1, 3],
+			controller: 1,
+		},
+		{
+			card_name: 'Guardian Tunneler',
+			loc: [2, 4],
+			controller: 1,
+		},
+		{
+			card_name: 'Guardian Tunneler',
+			loc: [3, 3],
+			controller: 1,
+		},
+		{
+			card_name: 'Guardian Tunneler',
+			loc: [4, 3],
+			controller: 1,
+		},
+	],
+},
+
 {
 	name: 'fetid-plague',
 	text: '',


### PR DESCRIPTION
Add test for (a strange?) situation regarding a silenced unengaged 'Guardian Tunneler' to end up with a -4 armor bonus.