### PR TITLE
Add playable test for occupied lands.

### DIFF
--- a/data/test-cases.cfg
+++ b/data/test-cases.cfg
@@ -934,4 +934,108 @@
 	],
 },
 
+//   Rationale
+//
+//   When this playable test was added, lands click was briefly broken.
+// This was added mainly to demonstrate it in a quickest way. So this
+// can probably just be removed. Anyway TODO this makes a good candidate
+// to automatic testing.
+{
+	name: 'clickable_lands',
+	text: '',
+	set: 'core',
+	avatar: 'village.png',
+	portrait: 'village.png',
+	portrait_scale: 0.2,
+	portrait_translate: [10, 20],
+	enemy_name: 'The People',
+	skip_mulligan: true,
+	player_resources: 20,
+	player_deck: [
+		'Silence'
+		, 'Silence'
+		, 'Testudo'
+		, 'Anthem of Battle'
+	],
+	bot_args: {
+		deck: "['Shield Bearer'] * 5 + ['Village'] * 10",
+	},
+
+	starting_units: [
+		{
+			card_name: "Village",
+			loc: [1, 2],
+		},
+		{
+			card_name: "Village",
+			loc: [1, 3],
+		},
+		{
+			card_name: "Village",
+			loc: [2, 3],
+//			controller: 0,
+		},
+		{
+			card_name: "Village",
+			loc: [3, 2],
+//			controller: 1,
+		},
+		{
+			card_name: "Village",
+			loc: [4, 3],
+//			controller: 2,
+		},
+		{
+			card_name: 'Shield Bearer',
+			loc: [0, 1],
+			controller: 0,
+		},
+		{
+			card_name: 'Shield Bearer',
+			loc: [1, 0],
+			controller: 0,
+		},
+		{
+			card_name: 'Catherine, Lady of the Blade',
+			loc: [2, 0],
+			controller: 0,
+		},
+		{
+			card_name: 'Shield Bearer',
+			loc: [3, 0],
+			controller: 0,
+		},
+		{
+			card_name: 'Shield Bearer',
+			loc: [4, 1],
+			controller: 0,
+		},
+		{
+			card_name: 'Eager Swordsman',
+			loc: [0, 3],
+			controller: 1,
+		},
+		{
+			card_name: 'Eager Swordsman',
+			loc: [1, 3],
+			controller: 1,
+		},
+		{
+			card_name: 'Oldric, Lord of the Hold',
+			loc: [2, 4],
+			controller: 1,
+		},
+		{
+			card_name: 'Eager Swordsman',
+			loc: [3, 3],
+			controller: 1,
+		},
+		{
+			card_name: 'Eager Swordsman',
+			loc: [4, 3],
+			controller: 1,
+		},
+	],
+},
+
 ]


### PR DESCRIPTION
I think something got broken with _occupied_ lands click; related to an activation of some strict mode (don't really know how many modes exist for FFL, less how many them are _strict_ (is that something similar to the JS strict mode..?) or how strict is any of them), from what I read in Anura console output.

Fix for the supposed trouble already coded, will show in a subsequent PR.

This was suddenly and discovered while doing thorough testing of some minor Anura changes subsequent PR.

Cheers and regards,