### PR TITLE
Add proposal of fix for issue in PR#108

### DIFF
--- a/data/objects/creature.cfg
+++ b/data/objects/creature.cfg
@@ -220,10 +220,15 @@
 		",
 
 		clicked: "def(int mouse_button=1) ->commands
-		if(option_index != null,
-		    controller.option_clicked(option_index, option_index),
+		if (self.option_index != null,
+			controller.option_clicked(self.option_index, self.option_index),
 		    _is_preview = false, [
-			if(controller.awaiting_input = false and arg.mouse_button = 1 and creature_object and creature_object.is_on_board and creature_object.controller = controller.myplayer.player_index and creature_object.can_move_not_blocked(controller.state),
+			if (controller.awaiting_input = false
+					and mouse_button = 1
+					and creature_object
+					and creature_object.is_on_board
+					and creature_object.controller = controller.myplayer.player_index
+					and creature_object.can_move_not_blocked(controller.state),
 			controller.send_move_creature_message(creature_object),
 			controller.awaiting_input = false and /*arg.mouse_button = 3 and*/ creature_object and creature_object.is_on_board and creature_object.activated_abilities and creature_object.controller = controller.myplayer.player_index,
 			[

--- a/data/test-cases.cfg
+++ b/data/test-cases.cfg
@@ -934,4 +934,108 @@
 	],
 },
 
+//   Rationale
+//
+//   When this playable test was added, lands click was briefly broken.
+// This was added mainly to demonstrate it in a quickest way. So this
+// can probably just be removed. Anyway TODO this makes a good candidate
+// to automatic testing.
+{
+	name: 'clickable_lands',
+	text: '',
+	set: 'core',
+	avatar: 'village.png',
+	portrait: 'village.png',
+	portrait_scale: 0.2,
+	portrait_translate: [10, 20],
+	enemy_name: 'The People',
+	skip_mulligan: true,
+	player_resources: 20,
+	player_deck: [
+		'Silence'
+		, 'Silence'
+		, 'Testudo'
+		, 'Anthem of Battle'
+	],
+	bot_args: {
+		deck: "['Shield Bearer'] * 5 + ['Village'] * 10",
+	},
+
+	starting_units: [
+		{
+			card_name: "Village",
+			loc: [1, 2],
+		},
+		{
+			card_name: "Village",
+			loc: [1, 3],
+		},
+		{
+			card_name: "Village",
+			loc: [2, 3],
+//			controller: 0,
+		},
+		{
+			card_name: "Village",
+			loc: [3, 2],
+//			controller: 1,
+		},
+		{
+			card_name: "Village",
+			loc: [4, 3],
+//			controller: 2,
+		},
+		{
+			card_name: 'Shield Bearer',
+			loc: [0, 1],
+			controller: 0,
+		},
+		{
+			card_name: 'Shield Bearer',
+			loc: [1, 0],
+			controller: 0,
+		},
+		{
+			card_name: 'Catherine, Lady of the Blade',
+			loc: [2, 0],
+			controller: 0,
+		},
+		{
+			card_name: 'Shield Bearer',
+			loc: [3, 0],
+			controller: 0,
+		},
+		{
+			card_name: 'Shield Bearer',
+			loc: [4, 1],
+			controller: 0,
+		},
+		{
+			card_name: 'Eager Swordsman',
+			loc: [0, 3],
+			controller: 1,
+		},
+		{
+			card_name: 'Eager Swordsman',
+			loc: [1, 3],
+			controller: 1,
+		},
+		{
+			card_name: 'Oldric, Lord of the Hold',
+			loc: [2, 4],
+			controller: 1,
+		},
+		{
+			card_name: 'Eager Swordsman',
+			loc: [3, 3],
+			controller: 1,
+		},
+		{
+			card_name: 'Eager Swordsman',
+			loc: [4, 3],
+			controller: 1,
+		},
+	],
+},
+
 ]


### PR DESCRIPTION
Add proposal of fix for issue in #108 (Anura assertion failed on clicking an _occupied_ land) in separate branch to help treating the problem and the proposed solution separately.

It seems to me the _crash_ problem comes from the activation of a strict mode (somewhere, I don't know where nor when) without a fully exhaustive check of all sources. I guess it is more appropriate fixing it forwards rather than reverting back the mode change.

Obviously this type of issues can be wiped out with full coverage, but am not at all positioned to make particular advice on that topic.

Cheers and regards,