### PR TITLE
Reduce dashes size in card placeholders.

### DIFF
--- a/data/objects/card.cfg
+++ b/data/objects/card.cfg
@@ -878,7 +878,7 @@
 			  c.restore(),
 
 			  c.set_line_cap(enum round),
-			  c.set_line_dashes([w*0.1, w*0.1]),
+			  c.set_line_dashes([w * 0.02, w * 0.02]),
 
 			  c.new_path(),
 			  c.translate(w*0.02, h*0.02),
@@ -891,7 +891,7 @@
 			  c.line_to(w*0.0, h*0.5),
 			  c.line_to(w*0.25, h*0.0),
 			  c.set_source_rgba(1, 1, 1, 0.5),
-			  c.set_line_width(w*0.03),
+			  c.set_line_width(w * 0.015),
 			  c.stroke(),
 			])
 		",


### PR DESCRIPTION
Reduce dashes size in card placeholders while some else sorts out a
more elaborate card placeholder... if I am not mistaken the current
plan is to have the normal card back, but with a lot of transparency.

See result:

![screenshot_20171019_164024](https://user-images.githubusercontent.com/3533348/31783267-330faa0a-b4ed-11e7-83e6-aa67dda3be73.png)
