### PR TITLE
Do not cast treason on own creatures.

### DIFF
--- a/data/cards-minerva.cfg
+++ b/data/cards-minerva.cfg
@@ -584,8 +584,8 @@
 		cost: 3,
 		loyalty_cost: 3,
 		is_response: true,
-		rules: "Remove target creature and put it in your hand.",
-		possible_targets: "all_creatures_as_possible_targets",
+		rules: "Remove target enemy creature and put it in your hand.",
+		possible_targets: "enemy_creatures_as_possible_targets",
 		
 		on_play: "def(class game_state game, class message.play_card info) ->commands
 		[


### PR DESCRIPTION
If an own creature was to become traitorous, it would go to opponent's
hand. Adapt card behavior to its name. Moving own creature to own hand
would not be treason but something such as strategic redeployment.