### PR TITLE
Point out candidate visual bug.

### DIFF
--- a/data/test-cases.cfg
+++ b/data/test-cases.cfg
@@ -1515,5 +1515,59 @@
 	],
 },
 
+//   When this playable test was added, the minervan card "Traitor" was
+// showing (briefly) a skull on the creature that was ready to be moved
+// back to a player's hand. You can remove this test if the 'death
+// skull' behavior is correct, or is not but it got fixed.
+{
+	name: 'treasons',
+	text: '',
+	set: 'core',
+	avatar: 'janus-the-great.png',
+	portrait: 'janus-the-great.png',
+	portrait_scale: 0.2,
+	portrait_translate: [10, 20],
+	enemy_name: 'Catherine',
+	skip_mulligan: true,
+	player_resources: 20,
+	player_deck: [
+		'Silence', 'Silence', 'Traitor', 'Traitor'
+	],
+	bot_args: {
+		deck: "['Shield Bearer'] * 5 + ['Village'] * 10",
+	},
+
+	starting_units: [
+		{ card_name: "Village", loc: [1, 2], },
+		{ card_name: "Village", loc: [1, 3], },
+		{ card_name: "Village", loc: [2, 3], },
+		{ card_name: "Village", loc: [3, 2], },
+		{ card_name: "Village", loc: [4, 3], },
+		{
+			card_name: 'Shield Bearer',
+			loc: [0, 1], controller: 0,
+		},
+		{
+			card_name: 'Catherine, Lady of the Blade',
+			loc: [2, 0], controller: 0,
+		},
+		{
+			card_name: 'Shield Bearer',
+			loc: [4, 1], controller: 0,
+		},
+		{
+			card_name: 'Eager Swordsman',
+			loc: [1, 3], controller: 1,
+		},
+		{
+			card_name: 'Oldric, Lord of the Hold',
+			loc: [2, 4], controller: 1,
+		},
+		{
+			card_name: 'Eager Swordsman',
+			loc: [3, 3], controller: 1,
+		},
+	],
+},
 
 ]


### PR DESCRIPTION
Adds playable test for pointing out 'Deception' and 'Traitor' are
showing a 'death skull' effect (briefly) on the creature they are
moving to a player's hand. Assuming that effect could be undesired.