### PR TITLE
 give Guardsman no more than 3 of each card

### DIFF
--- a/data/campaign-dialog/28ef14b4b257405e84ea58b3a49b1bc5.cfg
+++ b/data/campaign-dialog/28ef14b4b257405e84ea58b3a49b1bc5.cfg
@@ -2,7 +2,7 @@
 	"battle": {
 		"avatar": "shield-bearer.png",
 		"bot_args": {
-			"deck_list": ["Iron Warhammer","Iron Warhammer","Iron Warhammer","Longsword","Longsword","Longsword","Highlands","Highlands","Highlands","Wall of Stone","Wall of Stone","Wall of Stone","Wall of Stone","Mercenary","Mercenary","Mercenary","Mercenary","Mercenary","Mercenary","Mercenary","Shield Bearer","Shield Bearer","Shield Bearer","Shield Bearer","Shield Bearer","Shield Bearer","Shield Bearer","Eager Swordsman","Eager Swordsman","Eager Swordsman","Eager Swordsman","Eager Swordsman","Eager Swordsman","Eager Swordsman","Eager Swordsman","Loyal Guard","Loyal Guard","Loyal Guard","Loyal Guard","Loyal Guard","Loyal Guard","Loyal Guard","Loyal Guard","Man-at-Arms","Man-at-Arms","Man-at-Arms","Man-at-Arms","Man-at-Arms","Man-at-Arms","Man-at-Arms"]
+			"deck_list": ["Iron Warhammer","Iron Warhammer","Iron Warhammer","Longsword","Longsword","Longsword","Highlands","Highlands","Highlands","Wall of Stone","Wall of Stone","Wall of Stone","Mercenary","Mercenary","Mercenary","Shield Bearer","Shield Bearer","Shield Bearer","Loyal Guard","Loyal Guard","Loyal Guard","Man-at-Arms","Man-at-Arms","Man-at-Arms","Rune Warrior","Rune Warrior","Rune Warrior"]
 		},
 		"enemy_name": "Guardman",
 		"name": "Opponent",


### PR DESCRIPTION
The Guardsman, meant to be a beginner challenge right out of Shoalstill, may be a bit overpowered. The problem is having all those cheap efficient units (particularly the Loyal Guard) creates an incredible amount of pressure in the early-to-mid game.

simple fix: don't add or remove card types, just make it a <50 deck so
he can't spam units of the same type.

(I playtested this and it does seem to play out more fairly.)