### PR TITLE
Adjust `Rihn's monument`.

### DIFF
--- a/data/cards-adjustments.cfg
+++ b/data/cards-adjustments.cfg
@@ -1505,15 +1505,24 @@
 		"translate_y": 0.0
 	},
 	"Monument": {
-		"scale": 0.691,
-		"scale_enemy": 1.069,
-		"scale_friend": 1.192,
-		"translate_enemy_x": 0.019,
-		"translate_enemy_y": 0.275,
-		"translate_friend_x": -0.042,
-		"translate_friend_y": 0.139,
-		"translate_x": 0.162,
-		"translate_y": 0.185
+		"deck_entry_focus_scale": 0.206,
+		"deck_entry_focus_x": 365,
+		"deck_entry_focus_y": 495,
+		"focus_x": 0.5,
+		"focus_y": 0.5,
+		"focus_zoom": 0.03,
+		"scale": 0.709,
+		"scale_enemy": 1.578,
+		"scale_focus": 1.365,
+		"scale_friend": 1.503,
+		"translate_enemy_x": -0.214,
+		"translate_enemy_y": -0.033,
+		"translate_focus_x": -0.138,
+		"translate_focus_y": 0.013,
+		"translate_friend_x": -0.187,
+		"translate_friend_y": -0.023,
+		"translate_x": 0.156,
+		"translate_y": 0.146
 	},
 	"Nature's Blessing": {
 		"deck_entry_focus_scale": 0.387,

--- a/data/cards-colorless.cfg
+++ b/data/cards-colorless.cfg
@@ -123,7 +123,6 @@
 		school: "@eval FAITH",
 		rarity: -1,
 		portrait: "school-faith.png",
-		artist: "foo",
 		is_player_ability: true,
 		creature: {
 			name: 'Monument',

--- a/data/cards-colorless.cfg
+++ b/data/cards-colorless.cfg
@@ -123,6 +123,7 @@
 		school: "@eval FAITH",
 		rarity: -1,
 		portrait: "school-faith.png",
+		artist: "foo",
 		is_player_ability: true,
 		creature: {
 			name: 'Monument',


### PR DESCRIPTION
Motivation: `Monument` as seen at https://github.com/davewx7/citadel/pull/131.

That is:

<img width="1280" alt="screen shot 2017-10-26 at 22 21 59" src="https://user-images.githubusercontent.com/3533348/32075162-31016c3a-ba9c-11e7-98c5-bd9ef879c4c1.png">

Before this change:

<img width="1280" alt="screen shot 2017-10-26 at 21 41 28" src="https://user-images.githubusercontent.com/3533348/32074451-bb9f89f6-ba99-11e7-84b5-9b136bb1088e.png">

After this change:

<img width="1279" alt="screen shot 2017-10-26 at 22 01 53" src="https://user-images.githubusercontent.com/3533348/32074463-c985aaf0-ba99-11e7-8637-431da8e5cc51.png">

This makes: 

<img width="1280" alt="screen shot 2017-10-26 at 22 09 20" src="https://user-images.githubusercontent.com/3533348/32074993-91e781c0-ba9b-11e7-87a2-793764028a09.png">

or:

<img width="1280" alt="screen shot 2017-10-26 at 22 16 04" src="https://user-images.githubusercontent.com/3533348/32075018-ade041b4-ba9b-11e7-941d-e756d96d8cee.png">

Cheers and Regards,