### PR TITLE
Propose further iteration in the obelisks visuals.

### DIFF
--- a/data/cards-aether.cfg
+++ b/data/cards-aether.cfg
@@ -708,7 +708,7 @@ naught shall touch her chosen ones.",
 					color_mid: [0.7,0.7,0.9],
 					color_light: [1.0,1.0,0.9],
 					brighten: true,
-					alpha: 64,
+					alpha: 72,
 				},
 				static_effect: "def(class game_state game, class creature creature) ->commands
 				[   

--- a/data/cards-entropia.cfg
+++ b/data/cards-entropia.cfg
@@ -548,7 +548,7 @@
 					color_dark: [0.0,0.0,1.0],
 					color_mid: [0.5,0.5,0.8],
 					color_light: [0.0,0.0,0.0],
-					alpha: 64,
+					alpha: 128,
 				},
 				static_effect: "def(class game_state game, class creature creature) ->commands
 				if(creature.controller >=0, [   


### PR DESCRIPTION
This was the long lived previous iteration:
![screen shot 2017-10-29 at 18 33 21 copy 0](https://user-images.githubusercontent.com/3533348/32147584-257b8a4e-bcea-11e7-819b-cb077ecb11ec.png)

This is the current iteration, after the effects were requested to be more subtle:
![screen shot 2017-10-29 at 18 19 02 copy 1](https://user-images.githubusercontent.com/3533348/32147613-793725c6-bcea-11e7-80cb-c62194cc85f2.png)

I find that an excessive subtle, I am proposing them to be like these:
![screen shot 2017-10-29 at 18 28 50 copy 2](https://user-images.githubusercontent.com/3533348/32147619-a9ee96b8-bcea-11e7-9a7d-9871d6cc6b48.png)

Cheers,