### PR TITLE
Label changes in the off line mode.

### DIFF
--- a/data/objects/rival_pane.cfg
+++ b/data/objects/rival_pane.cfg
@@ -124,9 +124,61 @@
 			title_controller.display_choose_deck_controller(_rival_type = 1)
 
 		",
-
 		get_rivals: "def() ->[class rival]
-		[lib.citadel.tutorials, lib.citadel.rivals, lib.citadel.puzzles][_rival_type]
+		[
+			lib.citadel.tutorials,
+			// Multiplayer rivals can be removed from the list of
+			// rivals if the player is for sure off the line.
+			possibly_remove_multiplayer_rivals(lib.citadel.rivals),
+			lib.citadel.puzzles
+		][_rival_type]
+		",
+
+		possibly_remove_multiplayer_rivals: "def
+			([class rival] rivals) -> [class rival]
+			if (title_controller.offline_mode,
+				filter(
+					rivals,
+					not is_multiplayer_rival(value)),
+				rivals)
+		",
+
+		is_multiplayer_rival: "def
+			(class rival rival_) -> bool
+			matches(rival_.name, 'ultiplayer')
+		",
+
+		matches: "def
+			(string haystack, string needle) -> bool
+//			dump(['matches', haystack, needle, result],
+			result
+//			)
+			where result =
+				if (size(haystack) = 0 and size(needle) > 0,
+					false,
+				if (starts_with(haystack, needle),
+					true,
+				matches(haystack[1:], needle)))
+		",
+
+		starts_with: "def
+			(string haystack, string needle) -> bool
+//			dump(['starts_with', haystack, needle, result],
+			result
+//			)
+			where result =
+				if (size(needle) = 0,
+					bool <- true,
+				if (size(haystack) = 0,
+					bool <- false,
+				if (haystack[0] = needle[0],
+					bool <- starts_with(
+						string <- haystack[1:],
+						string <- needle[1:]),
+					bool <- false)
+				asserting
+					size(haystack) > 0
+					and size(needle) > 0))
 		",
 
 		_create_difficulty_combo: "def(obj rival_avatar avatar) ->commands [
@@ -211,7 +263,13 @@
 				}),
 			]));
 
-			set(_selected_rival, find(_rivals, value.rival.name = 'Multiplayer Challenge') or _rivals[0]);
+			set(_selected_rival,
+				find(_rivals,
+					value.rival.name = 'Multiplayer Challenge')
+					// This will activate if the player is off the line.
+					or find(_rivals,
+						value.rival.name = 'Random Rival')
+					or _rivals[0]);
 
 			remove_object(_map_combo);
 			set(_map_combo, null);

--- a/data/objects/title_controller.cfg
+++ b/data/objects/title_controller.cfg
@@ -826,7 +826,7 @@
 				zorder: 200,
 				_width: lib.gui.py(220),
 				_portrait: 'staged-duel.png',
-				_name: 'Multiplayer',
+				_name: if (offline_mode, 'Single player', 'Multiplayer'),
 				click_handler: def(obj title_option_widget w)->commands me.enter_multi(),
 			}),
 


### PR DESCRIPTION
data/objects/rival_pane.cfg: If the mode is off line, remove the
'Multiplayer Challenge' from the list of rivals. Make the 'Random
Rival' the default rival for the off line mode.

data/objects/title_controller.cfg: If the mode is off line, change the
'Multiplayer' label for something like 'Single Player'.