### PR TITLE
Adapt `Lethal` tip to current facts.

### DIFF
--- a/data/help-abilities.cfg
+++ b/data/help-abilities.cfg
@@ -20,7 +20,7 @@
 	"Cove": "This land is not affected by Marauder",
 	"Range": "RANGE",
 	"Ranged": "This creature can attack after moving. It does not counter-attack and cannot be counter-attacked.",
-	"Lethal": "When this creatures damages an enemy in combat, it destroys them.",
+	"Lethal": "When this creatures damages an enemy creature in combat, it destroys them.",
 	"Valiant": "Death due to loss of life is delayed until end of turn.",
 	"Building": "Buildings do not move like creatures do, and are not affected by spells or abilities that affect creatures.",
 	"Mobile": "This building is currently able to move.",


### PR DESCRIPTION
`Lethal` is not currently being against buildings, and I think that is
OK, so remove buildings from the definition of 'enemy' by specifying
`Lethal` destroys `creature` enemies.