### PR TITLE
Proposing color changes in card shadows while in hand.

### DIFF
--- a/data/objects/card.cfg
+++ b/data/objects/card.cfg
@@ -1935,7 +1935,10 @@
 			set(uniform_commands.u_alpha, min(parent.effect_alpha, parent.alpha/255.0)),
 			set(uniform_commands.u_edge, if(parent.halo_shown, 0.02, 0.02)),
 
-			set(uniform_commands.u_color, if(parent.card_type.shadow, [0.0,0.0,0.0,1.0], [1.0,1.0,1.0,1.0])),
+			set(uniform_commands.u_color,
+				if(parent.card_type.shadow,
+					[0.761, 0.098, 0.098, 1.0],
+					[0.078, 0.612, 0.078, 1.0])),
 
 			set(attribute_commands.a_position, float_array(
 			rotate_rect(


### PR DESCRIPTION
In the mid term I want to propose a noticeable particles for _shadow deck cards_. In the meanwhile, I thought it could be better to have it in red, more obvious to the newcomer while not awful to the tenured (I... guess...). I don't know sh about colors, but this neat tool http://paletton.com/#uid=2000u0krPopiwvknks1uCk1CHeV was telling green is complementary, so I added it to replace the white shadow of playable card. Why not..? I'm not sure, but it's like the green glow for playable card has already been suggested. 

<img width="1280" alt="screen shot 2017-11-06 at 23 27 23" src="https://user-images.githubusercontent.com/3533348/32467271-45b2d28e-c34a-11e7-9de5-558aa0efae93.png">

I'm aware that green glow on playable card is something present in other CCGs with _arguably not so dark thematic, ambience and storytelling_, so if you feel this doesn't fit well with the lore, just discard or silently ignore.

I don't really care that much if the playable card glow is white, green or even absent. For the _shadow deck card_ in the mid term I would be proposing a **very** dark clearly noticeable particles glow, more consistent with the current black shadow than with the proposed red shadow.

Still I would add this, maybe even just as being a community shaker.

Consider this change is not addressing opponent's hand separately. With this change, **card highlighted by the opponent is getting green**. I am happy to further iterate if anybody finds that required to deal with.

Actually, the treatment is being the same for _shadow deck cards_ in opponent's hand. **I am now discovering as I write that you can tell if a card in opponent's hand is from the standard deck or from one _shadow deck_ judging the _shadow_ the card gets when the opponent is hovering the card** on her/his end client. Was that an unintended side effect? Was it on purpose? Is it desirable?

Cheers and regards,
