### PR TITLE
Library UI overhaul

### DIFF
--- a/data/objects/card.cfg
+++ b/data/objects/card.cfg
@@ -122,8 +122,8 @@
 		   hide_halo(),
 	       controller.option_clicked(choice_index, choice_value),
 		],
-	
-	       switch(mouse_button, 
+
+	       switch(mouse_button,
 				1, controller.card_clicked(me),
 				3, controller.card_right_clicked(me),
 			null))
@@ -161,7 +161,7 @@
 			type: "decimal",
 			init: "
 				if('hue_shift' in adjustments, decimal<- adjustments['hue_shift'], card_type.hue_shift)
-		
+
 				where adjustments = lib.citadel.card_adjustments[card_type.internal_id] or {}
 			",
 		},
@@ -170,7 +170,7 @@
 			type: "decimal",
 			init: "
 				if('saturation_multiplier' in adjustments, decimal<- adjustments['saturation_multiplier'], 1.0)
-		
+
 				where adjustments = lib.citadel.card_adjustments[card_type.internal_id] or {}
 			",
 		},
@@ -179,7 +179,7 @@
 			type: "decimal",
 			init: "
 				if('luminance_multiplier' in adjustments, decimal<- adjustments['luminance_multiplier'], 1.0)
-		
+
 				where adjustments = lib.citadel.card_adjustments[card_type.internal_id] or {}
 			",
 		},
@@ -237,11 +237,11 @@
 		calculate_font_size: "def(int cur_size=16) ->int
 
 		if(find(fragments, value.y + value.height > max_height) = null, cur_size, calculate_font_size(cur_size-1))
-		
+
 			  where fragments = c.markup_text(q(<font size=') + cur_size + q('>) + card_type.rules_text + q(</font>), _rules_text_width*300.0, -1.0)
 			  where max_height = 90.0
 			  where c = canvas()
-		
+
 		",
 
 		show_card_tips: "def() ->commands execute(me, [
@@ -574,7 +574,7 @@
 				_play_resolve_launch_anim(),
 			];
 
-		   
+
 		   schedule(card_type.resolve_delay, ; [
 		  		animate(me, {
 					hud_alpha: 0.0,
@@ -631,7 +631,7 @@
 
 				_play_resolve_impact_anim(targets),
 		   ])),
-		
+
 			execute(me, [
 		   		map(arrows, animate(value, {
 					arrow_alpha: 0,
@@ -740,7 +740,7 @@
 			set(mid_y, start.mid_y),
 			set(rotate, start.rotate),
 			animate(me, {mid_x: mid_x, mid_y: mid_y, rotate: me.rotate, card_size: me.card_size}, {duration: ncycles}),
-			
+
 		]",
 
 		//card_type property which can be a card OR an activated_ability.
@@ -748,7 +748,7 @@
 		  type: "class card_base",
 		  get: "_data", set: "execute(me, [
 
-				set(_data, value), 
+				set(_data, value),
 				fire_event('init')
 			  ]) asserting value != null"
 		},
@@ -761,7 +761,7 @@
 		_loyalty_cost_per_school: "null|[int] ::
 		  if(player = null, null, map(card_type.school_list, min(card_type.loyalty_cost, player.get_resource_level(value))))
 		",
-		
+
 		_loyalty_cost: "int ::
 			if(player != null,
 			   player.calculate_card_loyalty_cost(card_type),
@@ -773,7 +773,7 @@
 			   player.calculate_card_base_cost(card_type),
 			   card_type.cost)
 		",
-		
+
 		render_size: "def(decimal size) ->[int,int] [round_to_even(lib.hex.width_from_height(height)), round_to_even(height)]
 		 where height = size*154*(screen_height/900.0)",
 
@@ -823,7 +823,7 @@
 			create_animation(
 			{
 				id: 'fbo',
-				image: 'fbo',			
+				image: 'fbo',
 				force_no_alpha: false,
 				fbo: tex,
 				x: 0, y: 0, w: ww+2, h: round_to_even((hh+2)*height_reduction_proportion),
@@ -1037,7 +1037,7 @@
 			  	scaling,
 			  	c.paint_image(alt_bg_name, null, [enum mask]),
 			  	c.restore(),
-				  
+
 			  ] where alt_bg_name = sprintf('images/card/%s_bg.png', alt_school_name)
 			  ),
 			  ]
@@ -1098,7 +1098,7 @@
 
 				  c.set_font_size(36*scaling),
 				  c.translate(if(drawn_cost >= 10, 0.862, 0.894)*w, 0.534*h),
-				  c.text_path(str(drawn_cost)), 
+				  c.text_path(str(drawn_cost)),
 				  c.fill(),
 
 				  ] where drawn_cost = if(player, _actual_cost, _base_cost),
@@ -1217,8 +1217,8 @@
 
 			  ], { filtering: 'bilinear', mipmaps:1, address_mode: ['clamp', 'clamp'] }
 
-			  
-		) 
+
+		)
 		where name_width = min(w*0.54, max(name_dim.width, w*0.25))
         where name_dim = c.text_extents(lib.font.bold_font, 18*scaling, card_type.name)
 		where text_color = c.set_source_rgba(card_type.text_color[0], card_type.text_color[1], card_type.text_color[2], 1)
@@ -1277,7 +1277,7 @@
 		_render_cost: "def(int ww, int hh, CostKey k) ->texture_object
 
 		c.render(ww/4, int(hh*0.6), [
-			
+
 			c.translate(-ww*0.7 - 1, 0),
 
 			  map(card_type.school_list,
@@ -1289,7 +1289,7 @@
 			  		c.paint_image(sprintf('images/card/%s_devotion_%s.png', lower(school_info[school_index].name), if(player and player.get_resource_level(school) <= index, 'off', 'on'))),
 					c.restore(),
 
-					
+
 				]
 				) where school = value
 				  where school_index = index
@@ -1314,7 +1314,7 @@
 
 			  c.set_font_size(36*scaling),
 			  c.translate(if(drawn_cost >= 10, 0.872, 0.894)*ww, 0.534*hh),
-			  c.text_path(str(drawn_cost)), 
+			  c.text_path(str(drawn_cost)),
 			  c.fill(),
 
 			  ] where drawn_cost = if(player, _actual_cost, _base_cost),
@@ -1322,7 +1322,7 @@
 			  c.restore(),
 		]
 		  where school_info = map(card_type.school_list, lib.citadel.school_info[value]),
-		
+
 		{ filtering: 'bilinear', mipmaps:1, address_mode: ['clamp', 'clamp'] }
 		)
 
@@ -1358,7 +1358,7 @@
 				icon: 'armor.svg',
 				scaling: 1.2,
 			}], []) +
-		
+
 		[{
 			text: ability.text,
 			icon: ability.icon,
@@ -1463,7 +1463,7 @@
 		),
 
 		set(_last_cost_key, _calculate_cost_key),
-		
+
 		set(image_texture, image_tex),
 		set(second_image_texture, second_image_tex),
 		if(image_tex, [
@@ -1712,7 +1712,7 @@
 	},
 
 	effects: [
-	
+
 	{
 		name: "card_shadow",
 		create: "[
@@ -1783,7 +1783,7 @@
 		"uniforms": {
 			"mvp_matrix": "u_mvp_matrix",
 		},
-		
+
 		draw: "[
 			set(uniform_commands.u_alpha, min(parent.effect_alpha, parent.alpha/255.0)),
 			set(attribute_commands.a_position, float_array(
@@ -1866,7 +1866,7 @@
 		"uniforms": {
 			"mvp_matrix": "u_mvp_matrix",
 		},
-		
+
 		//TODO: There seems to be a one-frame lag between when the
 		//a_position is updated and when it takes effect. Work out
 		//why this is instead of using shader_enabled_at to delay
@@ -1900,4 +1900,3 @@
 
 	],
 }
-

--- a/data/objects/library_book_view_controller.cfg
+++ b/data/objects/library_book_view_controller.cfg
@@ -3,8 +3,8 @@
 	prototype: ["library_view_controller"],
 
 	properties: {
-		_num_rows: "int :: 3",
-		_num_cols: "int :: 3",
+		_num_rows: "int :: 2",
+		_num_cols: "int :: 4",
 		_max_per_page: "int :: _num_rows*_num_cols",
 
 		_pages: { type: "[CardGroup]", default: [] },
@@ -30,7 +30,7 @@
 		_queued_goto_page: { type: "int|null" },
 		_anim_ends_at: { type: "int|null" },
 
-		_scroll_widget_pos: "int :: lib.citadel.py(110)",
+		_scroll_widget_pos: "int :: lib.citadel.py(15)",
 
 		_school_name_label: { type: "obj label|null" },
 		_school_icon: { type: "obj game_icon|null" },
@@ -59,10 +59,10 @@
 			[
 				remove_object(_school_name_label),
 				spawn('label', 0, 0, {
-					mid_x: (gui_left_edge + view_right_edge)/2,
-					mid_y: lib.citadel.py(30),
+					mid_x: (gui_left_edge + view_right_edge)/2 + lib.citadel.py(5),
+					mid_y: lib.citadel.py(110),
 					_halign: 'center',
-					_font_size: lib.citadel.py(32),
+					_font_size: lib.citadel.py(40),
 					_text: [_pages[npage].name],
 				}, [
 					set(_school_name_label, child),
@@ -76,9 +76,9 @@
 						draw_color: [0.0,0.0,0.0,1.0],
 						additional_icons: ['school-hex.svg'],
 						additional_colors: [[decimal,decimal,decimal]<- _pages[npage].icon_color],
-						size: lib.citadel.py(38),
-						mid_x: (gui_left_edge + view_right_edge)/2 - lib.citadel.py(85),
-						mid_y: lib.citadel.py(30),
+						size: lib.citadel.py(54),
+						mid_x: (gui_left_edge + view_right_edge)/2 + lib.citadel.py(5),
+						mid_y: lib.citadel.py(50),
 					}, [
 						set(_school_icon, child),
 					]),
@@ -88,10 +88,10 @@
 				set(_queued_goto_page, null),
 				remove_object(_page_label),
 				spawn('label', 0, 0, {
-					mid_x: gui_left_edge + lib.citadel.py(628) + _scroll_widget_pos,
-					mid_y: lib.citadel.py(872),
+					mid_x: gui_left_edge + lib.citadel.py(420) + _scroll_widget_pos,
+					mid_y: lib.citadel.py(710),
 					_halign: 'center',
-					_font_size: lib.citadel.py(16),
+					_font_size: lib.citadel.py(20),
 					_text: ['Page ' + str(npage+1) + '/' + str(size(_pages))],
 				}, [
 					set(_page_label, child)
@@ -123,8 +123,8 @@
 				set(_quantity_labels, []),
 
 				map(cards, [
-					set(value.x, gui_left_edge + lib.citadel.py(290)*(index%3)),
-					set(value.y, lib.citadel.py(60) + lib.citadel.py(240)*(index/3)),
+					set(value.x, lib.citadel.py(95) + lib.citadel.py(270)*(index%4)),
+					set(value.y, lib.citadel.py(155) + lib.citadel.py(260)*(index/4)),
 					set(value.clip_area, null),
 
 					if(entry.num_copies = 0, set(value.image_grayscale, 1.0),
@@ -143,11 +143,11 @@
 					   set(value.alpha, 255)
 					),
 
-					if(controller.showing_shop and entry.num_copies < 3, [
+					if(controller.showing_shop and entry.num_copies < 4, [
 						if(controller.account_gold >= lib.citadel.card_gold_cost(entry.card),
 						spawn('button_controller', {
-							x: gui_left_edge + lib.citadel.py(290)*(index%3) + lib.citadel.py(240),
-							y: lib.citadel.py(250) + lib.citadel.py(240)*(index/3) - lib.citadel.py(160),
+							x: gui_left_edge + lib.citadel.py(270)*(index%4) + lib.citadel.py(120),
+							y: lib.citadel.py(230) + lib.citadel.py(260)*(index/4) - lib.citadel.py(50),
 
 							button_width: lib.citadel.py(40),
 							button_height: lib.citadel.py(20),
@@ -160,11 +160,11 @@
 						),
 
 						spawn('label', 0, 0, {
-							x2: gui_left_edge + lib.citadel.py(290)*(index%3) + lib.citadel.py(280),
-							y: lib.citadel.py(220) + lib.citadel.py(240)*(index/3) - lib.citadel.py(170),
+							x2: gui_left_edge + lib.citadel.py(270)*(index%4) + lib.citadel.py(170),
+							y: lib.citadel.py(200) + lib.citadel.py(260)*(index/4) - lib.citadel.py(60),
 							_text: [str(lib.citadel.card_gold_cost(entry.card)) + ' gold'],
 							_font_size: lib.citadel.py(16),
-	
+
 							zorder: -1,
 
 							_color: if(controller.account_gold >= lib.citadel.card_gold_cost(entry.card), [1,1,1,1], [1,0,0,1]),
@@ -174,8 +174,8 @@
 					]),
 
 					spawn('label', 0, 0, {
-						x2: gui_left_edge + lib.citadel.py(290)*(index%3) + lib.citadel.py(270),
-						y: lib.citadel.py(220) + lib.citadel.py(240)*(index/3),
+						x2: gui_left_edge + lib.citadel.py(270)*(index%4) + lib.citadel.py(150),
+						y: lib.citadel.py(320) + lib.citadel.py(260)*(index/4),
 						_text: if(ncards = null, ['x' + str(entry.num_copies)], [str(ncards) + '/' + str(entry.num_copies)]) where ncards = controller.num_cards_in_deck(entry.name),
 						_bg_color: [0.04,0.06,0.09,1.0],
 						_font_size: lib.citadel.py(24),
@@ -219,22 +219,22 @@
 	on_create: "[
 		spawn('game_icon', 0, 0, {
 			icon: 'library-arrow.svg',
-			size: lib.citadel.py(38),
+			size: lib.citadel.py(116),
 			facing: -1,
 			force_no_alpha: true,
-			mid_x: gui_left_edge + lib.citadel.py(568) + _scroll_widget_pos,
-			mid_y: lib.citadel.py(870),
+			mid_x: lib.citadel.py(10) + _scroll_widget_pos,
+			mid_y: lib.citadel.py(400),
 			click_handler: def(obj game_icon icon) ->commands _goto_page(_current_page-1),
 			mouse_enter_handler: def(obj game_icon icon) ->commands set(icon.brightness, 512),
 			mouse_leave_handler: def(obj game_icon icon) ->commands set(icon.brightness, 255),
 		}),
 		spawn('game_icon', 0, 0, {
 			icon: 'library-arrow.svg',
-			size: lib.citadel.py(38),
+			size: lib.citadel.py(116),
 			facing: 1,
 			force_no_alpha: true,
-			mid_x: gui_left_edge + lib.citadel.py(688) + _scroll_widget_pos,
-			mid_y: lib.citadel.py(870),
+			mid_x: gui_left_edge + lib.citadel.py(1030) + _scroll_widget_pos,
+			mid_y: lib.citadel.py(400),
 			click_handler: def(obj game_icon icon) ->commands _goto_page(_current_page+1),
 			mouse_enter_handler: def(obj game_icon icon) ->commands set(icon.brightness, 512),
 			mouse_leave_handler: def(obj game_icon icon) ->commands set(icon.brightness, 255),

--- a/data/objects/library_book_view_controller.cfg
+++ b/data/objects/library_book_view_controller.cfg
@@ -143,7 +143,7 @@
 					   set(value.alpha, 255)
 					),
 
-					if(controller.showing_shop and entry.num_copies < 4, [
+					if(controller.showing_shop and entry.num_copies < 3, [
 						if(controller.account_gold >= lib.citadel.card_gold_cost(entry.card),
 						spawn('button_controller', {
 							x: gui_left_edge + lib.citadel.py(270)*(index%4) + lib.citadel.py(120),

--- a/data/objects/library_controller.cfg
+++ b/data/objects/library_controller.cfg
@@ -1265,7 +1265,7 @@
 			execute(me, [spawn(
 				'combo_controller',
 				{
-					x: gui_right_edge - py(765),
+					x: gui_right_edge - py(790),
 					y: level_height - py(110),
 					items: map(
 						lib.citadel.card_sets,
@@ -1273,10 +1273,10 @@
 					selected_index:
 						requested_selected_index,
 					on_change: me._change_set,
-					_width: lib.gui.py(130),
+					_width: lib.gui.py(190),
 					_height: lib.gui.py(23),
 					zorder: 1000,
-					_font_size: lib.gui.py(20),
+					_font_size: lib.gui.py(18),
 					color_scheme: lib.citadel
 						.library_color_scheme,
 				}, [
@@ -1362,7 +1362,7 @@
 		where pos = if(index = 0, 5, index-1)
 		),
 
-		map(_type_names, spawn('game_icon', gui_left_edge + lib.gui.py(450) + lib.gui.py(50)*index, level_height - lib.gui.py(59), {
+		map(_type_names, spawn('game_icon', gui_left_edge + lib.gui.py(460) + lib.gui.py(50)*index, level_height - lib.gui.py(59), {
 			icon: ['type-creature.svg', 'type-spell.svg', 'type-land.svg'][index],
 			tooltip_text: [
 				'Creatures',

--- a/data/objects/library_controller.cfg
+++ b/data/objects/library_controller.cfg
@@ -65,7 +65,7 @@
 		   map(filter(_mm_client_state.account_info.collection, value.name in cards_in_sets), value.name)
 		   where cards_in_sets = lib.citadel.get_cards_in_set(_set_id)
 		  )",
-		
+
 		get_collection_all_sets: "def() -> [string]
 		if(specified_collection != null, specified_collection, map(_mm_client_state.account_info.collection, value.name))
 		",
@@ -106,10 +106,10 @@
 
 		_deck_summaries: { type: "[obj library_deck_summary]", default: []},
 
-		_title_deck_summary_ypos: "int :: 0",
+		_title_deck_summary_ypos: "int :: 15",
 
 		_deck_summary_ypos: "def(int n) ->int
-			lib.gui.py(36) + lib.gui.py(66)*n
+			lib.gui.py(49) + lib.gui.py(71)*n
 		",
 
 		_spawn_deck_summaries: "def() ->commands
@@ -125,7 +125,7 @@
 					original_deck_name: value.name,
 					_controller: me,
 					_mm: me,
-					x2: gui_right_edge - lib.gui.py(24),
+					x2: gui_right_edge - lib.gui.py(-125),
 					y: _deck_summary_ypos(index),
 					alpha: 0,
 				}, [
@@ -167,8 +167,8 @@
 		_spawn_active_decks_label: "def() ->commands
 		if(_active_decks_label = null,
 			spawn('label', 0, 0, {
-				mid_x: gui_right_edge - lib.gui.py(200),
-				mid_y: lib.gui.py(24),
+				mid_x: gui_right_edge - lib.gui.py(50),
+				mid_y: lib.gui.py(34),
 				_font_size: lib.gui.py(26),
 				_text: ['ACTIVE DECKS'],
 			}, [
@@ -211,7 +211,7 @@
 				replace_existing: true,
 			})
 		)
-			where xpos = gui_right_edge - lib.gui.py(24)
+			where xpos = gui_right_edge - lib.gui.py(-125)
 			where ypos = _deck_summary_ypos(count(_decks, not value.archived))
 		)
 		]
@@ -286,14 +286,14 @@
 			remove_object(_gold_label),
 
 			spawn('label', {
-				x2: gui_right_edge - py(310),
-				y: level_height - py(100),
-				_font_size: lib.gui.py(16),
+				x2: gui_right_edge - py(305),
+				y: level_height - py(130),
+				_font_size: lib.gui.py(18),
 				_text: [str(account_gold) + ' gold'],
 			}, [
 				set(_gold_label, child),
 			]),
-			
+
 		]",
 
 		open_shop: "def() ->commands
@@ -304,8 +304,8 @@
 		[remove_object(c) | c <- _combos, c.grouping in ['shop','archives']],
 
 		spawn('combo_label', {
-			x2: gui_right_edge - py(130),
-			y: level_height - py(54),
+			x2: gui_right_edge - py(140),
+			y: level_height - py(74),
 			_text: 'Close Shop',
 			_font_size: py(26),
 			grouping: 'shop',
@@ -357,7 +357,7 @@
 				})
 			])
 			where rect = [decimal(gui_left_edge)/decimal(level_width), 0.0, decimal(gui_right_edge - lib.gui.py(300))/decimal(level_width), 1.0],
-			
+
 		]) where transition_time = 20
 		",
 
@@ -366,8 +366,8 @@
 			[[set(c.paused, false), add(c.zorder,-10000)] | c <- level.chars, c.paused],
 
 			spawn('combo_label', 0, 0, {
-				x2: gui_right_edge - py(20),
-				y: level_height - py(54),
+				x2: gui_right_edge - py(30),
+				y: level_height - py(74),
 				_text: 'Back to Library',
 				_font_size: py(26),
 				grouping: 'back',
@@ -415,7 +415,7 @@
 				})
 			])
 			where rect = [decimal(gui_left_edge)/decimal(level_width), 0.0, decimal(gui_right_edge - lib.gui.py(300))/decimal(level_width), 1.0],
-		
+
 		]) where transition_time = 20",
 
 		leave_archives: "def() ->commands
@@ -471,7 +471,7 @@
 
 		(not card.animated_movements) and card in (list<- _card_cache.enumerate) and not _focus_card and (find(level.chars, value is obj card and ('focus' in value.animated_movements)) = null),
 		[
-			
+
 			set(_focus_card, card),
 			[set(c.paused, true) | c <- level.chars, c not in [card,me]],
 			spawn('blur_controller', 0, 0, {
@@ -525,7 +525,7 @@
 		])
 		where num_cards = sum(map(deck, value.count))
 		);
-		
+
 		mouseover_card(card.card_type)",
 
 		remove_deck_prompt: "def(null|obj library_deck_summary summary, string deck_name) ->commands
@@ -690,7 +690,7 @@
 				deck_name: deck_name,
 				_controller: me,
 				_mm: me,
-				x2: gui_right_edge - lib.gui.py(24),
+				x2: gui_right_edge - lib.gui.py(-125),
 				y: _deck_summary_ypos(count(level.chars, value is obj library_deck_summary)),
 			}, [
 				add(_deck_summaries, [child]);
@@ -707,7 +707,7 @@
 				deck_name: deck.name,
 				_controller: me,
 				_mm: me,
-				x2: gui_right_edge - lib.gui.py(24),
+				x2: gui_right_edge - lib.gui.py(-125),
 				y: _deck_summary_ypos(count(level.chars, value is obj library_deck_summary)),
 			}, [
 				add(_deck_summaries, [child]),
@@ -738,8 +738,8 @@
 			}),
 
 			spawn('button_controller', 0, 0, {
-				mid_x: gui_right_edge - lib.gui.py(60),
-				mid_y: lib.gui.py(800),
+				mid_x: gui_right_edge - lib.gui.py(0),
+				mid_y: lib.gui.py(790),
 				text: 'Done',
 				on_click: me.done_editing_deck,
 			}, [
@@ -758,7 +758,7 @@
 		])
 		)
 		)",
-		
+
 		done_editing_deck: "def() ->commands execute(me, [
 			lib.sound.play_sound(me, 'interface/done-editing-deck'),
 			remove_object(cards_widget),
@@ -827,10 +827,10 @@
 			remove_object(cards_widget),
 
 			spawn('scrollable_pane', 0, 0, {
-				x: gui_right_edge - lib.gui.py(290),
-				y: lib.gui.py(78),
+				x: gui_right_edge - lib.gui.py(160),
+				y: lib.gui.py(98),
 				area_width: lib.gui.py(290),
-				area_height: lib.gui.py(680),
+				area_height: lib.gui.py(655),
 				left_align: false,
 				step_size: lib.gui.py(36),
 
@@ -902,7 +902,7 @@
 			_play_card_add_sound(),
 			new_obj.pulse()
 		]; view.update_card_quantity(card.name),
-		
+
 			lib.sound.play_sound(me, 'interface/ui_error')
 		)
 		where ypos = lib.gui.py(36)*insert_index
@@ -925,7 +925,7 @@
 			play_card_remove_sound(),
 
 			remove_object(entry),
-			
+
 			let old_elements = map(cards_widget.elements, {obj: value.obj, ypos: value.ypos});
 			[
 			[
@@ -981,7 +981,7 @@
 				controller: me,
 				in_hand: false,
 				allow_drag: false,
-				card_size: 1.5,
+				card_size: 1.4,
 				show_shadow: false,
 				use_absolute_screen_coordinates: true,
 				search_string: _search_terms,
@@ -1222,9 +1222,9 @@
 		remove_object(_search_entry),
 
 		spawn('text_entry', {
-			x: gui_left_edge + lib.gui.py(480),
-			y: level_height - lib.gui.py(36),
-			_width: lib.gui.py(140),
+			x: gui_left_edge + lib.gui.py(610),
+			y: level_height - lib.gui.py(71),
+			_width: lib.gui.py(160),
 			default_text: 'Search',
 			_on_change: def()->commands fire_event(me, 'search_changed'),
 		}, [
@@ -1265,7 +1265,7 @@
 			execute(me, [spawn(
 				'combo_controller',
 				{
-					x: gui_right_edge - py(710),
+					x: gui_right_edge - py(765),
 					y: level_height - py(110),
 					items: map(
 						lib.citadel.card_sets,
@@ -1273,10 +1273,10 @@
 					selected_index:
 						requested_selected_index,
 					on_change: me._change_set,
-					_width: lib.gui.py(120),
-					_height: lib.gui.py(16),
+					_width: lib.gui.py(130),
+					_height: lib.gui.py(23),
 					zorder: 1000,
-					_font_size: lib.gui.py(12),
+					_font_size: lib.gui.py(20),
 					color_scheme: lib.citadel
 						.library_color_scheme,
 				}, [
@@ -1297,8 +1297,8 @@
 
 		if(not _force_edit_deck,
 		spawn('combo_label', 0, 0, {
-			x: gui_left_edge + py(14),
-			y: level_height - py(54),
+			x: gui_left_edge + py(-80),
+			y: level_height - py(74),
 			_text: 'Main Menu',
 			_font_size: py(26),
 			left_rect: lib.gui.py(-4),
@@ -1313,8 +1313,8 @@
 
 		if(not _god_mode,
 			spawn('combo_label', 0, 0, {
-				x2: gui_right_edge - py(130),
-				y: level_height - py(54),
+				x2: gui_right_edge - py(140),
+				y: level_height - py(74),
 				_text: 'Shop',
 				_font_size: py(26),
 				grouping: 'shop',
@@ -1326,8 +1326,8 @@
 		),
 
 		spawn('combo_label', 0, 0, {
-			x2: gui_right_edge - py(20),
-			y: level_height - py(54),
+			x2: gui_right_edge - py(30),
+			y: level_height - py(74),
 			_text: 'Archives',
 			_font_size: py(26),
 			grouping: 'archives',
@@ -1337,7 +1337,7 @@
 			add(me._combos, [child]),
 		]),
 
-		map(range(0,6), spawn('game_icon', gui_left_edge + lib.gui.py(190) + lib.gui.py(50)*pos, level_height - lib.gui.py(34), {
+		map(range(0,6), spawn('game_icon', gui_left_edge + lib.gui.py(110) + lib.gui.py(53)*pos, level_height - lib.gui.py(59), {
 			icon: lib.citadel.school_info[value].icon,
 			tooltip_text: [
 				'Neutral',
@@ -1353,7 +1353,7 @@
 			force_no_alpha: true,
 			size: lib.gui.py(48),
 			click_handler: def(obj game_icon icon) ->commands select_school_filter(index),
-			mouse_enter_handler: def(obj game_icon icon) ->commands set(icon.brightness, 512),
+			mouse_enter_handler: def(obj game_icon icon) ->commands set(icon.brightness, 255),
 			mouse_leave_handler: def(obj game_icon icon) ->commands set(icon.brightness, if(_school_filter = [] or index in _school_filter, 255, 64)),
 			use_absolute_screen_coordinates: true,
 		}, [
@@ -1362,7 +1362,7 @@
 		where pos = if(index = 0, 5, index-1)
 		),
 
-		map(_type_names, spawn('game_icon', gui_left_edge + lib.gui.py(510) + lib.gui.py(40)*index, level_height - lib.gui.py(64), {
+		map(_type_names, spawn('game_icon', gui_left_edge + lib.gui.py(450) + lib.gui.py(50)*index, level_height - lib.gui.py(59), {
 			icon: ['type-creature.svg', 'type-spell.svg', 'type-land.svg'][index],
 			tooltip_text: [
 				'Creatures',
@@ -1372,7 +1372,7 @@
 			size: lib.gui.py(38),
 			force_no_alpha: true,
 			click_handler: def(obj game_icon icon) ->commands select_type_filter(_type_names[index]),
-			mouse_enter_handler: def(obj game_icon icon) ->commands set(icon.brightness, 512),
+			mouse_enter_handler: def(obj game_icon icon) ->commands set(icon.brightness, 255),
 			mouse_leave_handler: def(obj game_icon icon) ->commands set(icon.brightness, if(_type_filter = [] or (_type_names[index] in _type_filter), 255, 64)),
 			use_absolute_screen_coordinates: true,
 		}, [
@@ -1396,7 +1396,7 @@
 
 		spawn('game_icon', {
 			mid_x: gui_left_edge + lib.gui.py(840),
-			mid_y: lib.gui.py(870),
+			mid_y: lib.gui.py(842),
 			icon: 'open-book.svg',
 			size: lib.gui.py(34),
 			force_no_alpha: true,
@@ -1414,7 +1414,7 @@
 
 		spawn('game_icon', {
 			mid_x: gui_left_edge + lib.gui.py(890),
-			mid_y: lib.gui.py(870),
+			mid_y: lib.gui.py(842),
 			icon: 'library-grid.svg',
 			size: lib.gui.py(34),
 			force_no_alpha: true,
@@ -1465,10 +1465,10 @@
 		fire_event('dimensions_updated'),
 	] where new_width = max(int<- arg.width,800)-1
 	  where new_height = max(int<- arg.height, 600)-1",
-*/	
+*/
 	on_dimensions_updated: "[
 	]",
-	
+
 	on_type_updated: "fire_event('create')",
 
 	on_being_removed: "[
@@ -1495,7 +1495,7 @@
 			refresh_view()
 		)
 	]
-		
+
 	  where new_visible_cards = [{
 		name: 'Search Results',
 		entries: _default_sort(filter(_all_cards, find(value.card.school_list, school_in_filter(value)) != null and type_in_filter(value.card) and value.card.matches_search(map(search_words, '.*\\b' + value + '.*')) and

--- a/data/objects/library_deck_summary.cfg
+++ b/data/objects/library_deck_summary.cfg
@@ -163,7 +163,7 @@
 				),
 				c.translate(py(4), py(56)),
 				c.set_font(_font),
-				c.set_font_size(_font_size),
+				c.set_font_size(py(14)),
 				c.text_path_in_bounds(txt, area.width, ['left']),
 				c.fill(),
 				c.restore(),
@@ -172,7 +172,7 @@
 
 				[
 					c.save(),
-					c.translate(py(90), py(32)),
+					c.translate(py(95), py(32)),
 					c.set_source_color([1,1,1,1]),
 
 					map(text_fragments, [
@@ -195,7 +195,7 @@
 
 					c.restore(),
 				] where text_fragments = c.markup_text(stats_text, { width: area.width*0.75, scale: lib.citadel.dpy(1.0) })
-				  where stats_text = q(<font size='12'>) + 
+				  where stats_text = q(<font size='13'>) +
 				    q(<img src='images/icons/type-creature.svg'></img>) + str(num_creatures + num_buildings) + q( ) +
 				    q(<img src='images/icons/type-spell.svg'></img>) + str(num_spells) + q( ) +
 				    q(<img src='images/icons/type-land.svg'></img>) + str(num_lands) + q(\n) +
@@ -203,7 +203,7 @@
 					fold(map(school_counts, if(value > 0, q(<font tag='school-) + str(index+1) + q('><img src='images/icons/) + lib.citadel.school_info[index+1].icon + q('></img></font>) + str(value) + q( ), '')), a+b, '') +
 
 				  q(</font>),
-				
+
 				/*fold([
 				  if(num_creatures, str(num_creatures) + ' creatures', ''),
 				  if(num_buildings, str(num_buildings) + ' forts', ''),
@@ -335,7 +335,7 @@
 	]",
 
 	on_finish_editing_name: "
-	
+
 	   change_deck_name(_name_entry_widget.text asserting _name_entry_widget != null)
 	",
 

--- a/data/objects/library_scroll_view_controller.cfg
+++ b/data/objects/library_scroll_view_controller.cfg
@@ -59,7 +59,7 @@
 			filter(
 			map(flat_visible_cards,
 				if(value.num_copies < 3, {
-					xpos: lib.gui.py(240) + lib.gui.py(290)*(index%3),
+					xpos: lib.gui.py(220) + lib.gui.py(290)*(index%3),
 					ypos: lib.gui.py(6) + lib.gui.py(240)*(index/3),
 					height: lib.gui.py(60),
 					create: def()->custom_obj
@@ -75,8 +75,8 @@
 			filter(
 			map(flat_visible_cards,
 				if(value.num_copies < 3 and controller.account_gold >= lib.citadel.card_gold_cost(value.card), {
-					xpos: lib.gui.py(240) + lib.gui.py(290)*(index%3),
-					ypos: lib.gui.py(30) + lib.gui.py(240)*(index/3),
+					xpos: lib.gui.py(230) + lib.gui.py(290)*(index%3),
+					ypos: lib.gui.py(35) + lib.gui.py(240)*(index/3),
 					height: lib.gui.py(60),
 					create: def()->custom_obj
 					  object('button_controller', {
@@ -97,7 +97,7 @@
 				  controller.create_card(value.card)
 			})
 			where card_labels = map(flat_visible_cards, {
-				xpos: lib.citadel.py(216) + lib.citadel.py(290)*(index%3),
+				xpos: lib.citadel.py(200) + lib.citadel.py(290)*(index%3),
 				ypos: lib.citadel.py(170) + lib.citadel.py(240)*(index/3),
 				height: lib.citadel.py(60),
 				create: def()->custom_obj


### PR DESCRIPTION
- Changed the card grid in "book view". The grid is now 4x2 and not 3x3.
- Made the cards slightly smaller (from 1.5 to 1.4).
- Filter buttons were moved up and set on the same line.
- Filter buttons have changed brightness when mouse hovers over them.
- Name and icon of active school were enlarged and rearranged.
- The deck overview card was slightly changed (stats moved by few px).

I apologize for a lot of whitespace mess my editor did.