### PR TITLE
Ban small size fonts from land arrows when using small displays

### DIFF
--- a/data/objects/creature_land_flag.cfg
+++ b/data/objects/creature_land_flag.cfg
@@ -112,17 +112,36 @@
 			[
 				c.translate(ww/2 - area.width/2, 0),
 			]
-			  where area = c.text_extents(lib.font.regular_font, font_size, creature.creature_object.name),
+			where area = c.text_extents(
+				lib.font.regular_font, font_size,
+				presented_land_name
+			),
 			c.set_font(lib.font.regular_font),
 			c.set_font_size(font_size),
 			if(is_enemy, c.set_source_rgba(1,1,1,1), c.set_source_rgba(0,0,0,1)),
-			c.text_path(creature.creature_object.name),
+			c.text_path(presented_land_name),
 			c.fill(),
 		]
-		where font_size = lib.citadel.py(14) * if(base_area.width > hh * 0.55,
-			decimal(hh * 0.55) / decimal(base_area.width), 1.0)
-		 where base_area = c.text_extents(lib.font.regular_font, lib.citadel.py(14), creature.creature_object.name))
+		where font_size =
+//			dump([
+//				'font_size', lib.citadel.py(14), base_area.width, hh, hh * 0.55,
+//				decimal(hh * 0.55) / decimal(base_area.width), 1,
+//				lib.citadel.py(14) * 1.0,
+//				lib.citadel.py(14) * decimal(hh * 0.55) / decimal(base_area.width)
+//			], returning)
+//			where returning =
+			lib.citadel.py(14) *
+				if(base_area.width > hh * 0.55,
+					decimal(hh * 0.55) / decimal(base_area.width),
+				// else
+					1.0)
+		where base_area =
+//		dump(['base_area', presented_land_name], returning) where returning =
+		c.text_extents(lib.font.regular_font, lib.citadel.py(14), presented_land_name))
 		where c = canvas()
+		where presented_land_name =
+			creature.creature_object.name
+//			'abc efg ij..'
 		",
 	},
 

--- a/data/objects/creature_land_flag.cfg
+++ b/data/objects/creature_land_flag.cfg
@@ -127,7 +127,8 @@
 //				'font_size', lib.citadel.py(14), base_area.width, hh, hh * 0.55,
 //				decimal(hh * 0.55) / decimal(base_area.width), 1,
 //				lib.citadel.py(14) * 1.0,
-//				lib.citadel.py(14) * decimal(hh * 0.55) / decimal(base_area.width)
+//				lib.citadel.py(14) * decimal(hh * 0.55) / decimal(base_area.width),
+//				returning, presented_land_name
 //			], returning)
 //			where returning =
 			lib.citadel.py(14) *
@@ -136,12 +137,32 @@
 				// else
 					1.0)
 		where base_area =
-//		dump(['base_area', presented_land_name], returning) where returning =
+//		dump(['base_area', presented_land_name, returning], returning) where returning =
 		c.text_extents(lib.font.regular_font, lib.citadel.py(14), presented_land_name))
 		where c = canvas()
 		where presented_land_name =
-			creature.creature_object.name
-//			'abc efg ij..'
+			if(screen_width <= 1440,
+				prune_land_name(creature.creature_object.name),
+				creature.creature_object.name)
+		where prune_land_name = def
+			(string s) -> string
+			switch(size(controller.state.lanes),
+				1, prune_land_name_to(17, s),
+				3, prune_land_name_to(15, s),
+				5, prune_land_name_to(12, s),
+				2, prune_land_name_to(15, s),
+				4, prune_land_name_to(12, s),
+				s)
+		where prune_land_name_to = def
+			(int i, string s) -> string
+			if(size(s) > i,
+				if(use_unicode_ellipsis,
+					s[:i-1] + '…',
+					s[:i-3] + '...'),
+				s)
+			asserting i > 5
+			where use_unicode_ellipsis = true
+		where screen_width = level.dimensions[2]
 		",
 	},
 


### PR DESCRIPTION
These changes are attempting to provide larger font sizes as requested on https://github.com/davewx7/citadel/issues/186 and https://github.com/davewx7/citadel/issues/193.

Simplest demo:

<img width="1280" alt="screen shot 2018-02-26 at 23 04 48" src="https://user-images.githubusercontent.com/3533348/36699426-d915fe5c-1b4c-11e8-8a9a-2d52ce152b72.png">

Don't mind the color weirdness at the arrows' borders, those are spurious changes I removed before submitting.

Cheers and Regards,
