### PR TITLE
Center the text of the mana counter.

### DIFF
--- a/data/objects/mana_numeric_display.cfg
+++ b/data/objects/mana_numeric_display.cfg
@@ -62,7 +62,8 @@ properties: {
 				c.restore(),
 
 				c.save(),
-				c.translate(ww/2 - num_area.width/2, int(hh*0.65)),
+				c.translate(ww / 2 - num_area.width / 2,
+				            int(hh * .62)),
 				c.set_font(_font),
 				c.set_font_size(_font_size),
 				c.text_path(mana_str),


### PR DESCRIPTION
This centers the mana counter text at my 13" laptop (1152x648) by
pushing it a little bit upwards.

| where | before this | after this |
| - | - | - |
| 1152x648 | <img width="73" alt="screen shot 2018-05-12 at 23 39 47" src="https://user-images.githubusercontent.com/3533348/39961797-05533058-563e-11e8-9b0e-de5038ee8a49.png"> | <img width="71" alt="screen shot 2018-05-12 at 23 34 29" src="https://user-images.githubusercontent.com/3533348/39961800-05a528b8-563e-11e8-97f9-cc5079641d61.png"> |
| 1280x720 | <img width="78" alt="screen shot 2018-05-12 at 23 38 30" src="https://user-images.githubusercontent.com/3533348/39961798-056eb724-563e-11e8-9c7c-d72d00923028.png"> | <img width="79" alt="screen shot 2018-05-12 at 23 35 26" src="https://user-images.githubusercontent.com/3533348/39961799-058b3c3c-563e-11e8-9344-270b35403607.png"> |

I'll check larger resolutions before adding the change.
