### PR TITLE
Fix for `Overgrowth`.

### DIFF
--- a/data/particles/og_zero_a.cfg
+++ b/data/particles/og_zero_a.cfg
@@ -1,0 +1,106 @@
+//   This is an empty/transparent particle system with low energy
+// demands. It is now provided as a means for backwards compatibility.
+//   You can remove this in the future, but chances are similar cases
+// will happen until the root cause gets fixed.
+{
+	"info": {
+		"affector": [
+			{
+				"color_operation": "set",
+				"interpolate": true,
+				"time_color": [
+					{
+						"color": [0.0,0.0,0.0,0.0],
+						"time": 0.0
+					},
+					{
+						"color": [0.921568,0.97647,0.580392,0.0],
+						"time": 0.1
+					},
+					{
+						"color": [0.42745,0.941176,0.192156,0.0],
+						"time": 0.2
+					},
+					{
+						"color": [0.356862,0.666666,0.0,0.0],
+						"time": 0.25
+					},
+					{
+						"color": [0.541176,0.619607,0.109803,0.0],
+						"time": 0.5
+					},
+					{
+						"color": [0.42745,0.941176,0.192156,0.0],
+						"time": 0.75
+					},
+					{
+						"color": [0.921567,0.976469,0.580392,0.0],
+						"time": 1.0
+					}
+				],
+				"type": "color"
+			},
+			{
+				"max_deviation_x": 0.05,
+				"max_deviation_y": 0.1,
+				"max_deviation_z": 0.009998,
+				"scale": [25.316001,25.316001,1.0],
+				"time_step": 1.0,
+				"type": "randomizer"
+			},
+			{
+				"acceleration": {
+					"max": 0.333,
+					"min": 0.0,
+					"type": "random"
+				},
+				"type": "jet"
+			}
+		],
+		"blend": "alpha_blend",
+		"blend_enable": true,
+		"blend_equation": "add",
+		"default_particle_depth": 0.363999,
+		"default_particle_height": 82.909004,
+		"default_particle_width": 82.909004,
+		"emitter": {
+			"angle": {
+				"max": 360.0,
+				"min": 0.0,
+				"type": "random"
+			},
+			"can_be_deleted": false,
+			"emission_rate": {
+				"max": 4.0,
+				"min": 1.0,
+				"type": "random"
+			},
+			"emit_only_2d": true,
+			"mass": 1.0,
+			"name": "emit_object_15",
+			"rotation": {
+				"max": 360.0,
+				"min": 0.0,
+				"type": "random"
+			},
+			"scaling": 1.399999,
+			"time_to_live": {
+				"max": 1.0,
+				"min": 1.0,
+				"type": "random"
+			},
+			"type": "point",
+			"velocity": {
+				"max": 200.0,
+				"min": 100.000007,
+				"type": "random"
+			}
+		},
+		"name": "circle_portal",
+		"order": 0,
+		"particle_quota": 2000,
+		"scale": [0.4,0.1,0.0],
+		"scale_velocity": 0.1,
+		"texture": "particles/flare-128x128.png"
+	}
+}


### PR DESCRIPTION
`Overgrowth` is failing in one on one matches (i.e., not versus A.I.) because the central play server demands the `og_zero_a` particles doc to clients that were not having it anymore. This provides a backwards compatibility placeholder until the problem disappears.

This change is based on top of [a clean](https://github.com/davewx7/citadel/tree/6bab71651c40923c812fba2db4e2c06b98bc663e) version [1.0.682](https://github.com/davewx7/citadel/blob/master/module.cfg#L58-L62) because it cannot be tested using current `master`.

Current `master` changes the game code in ways not backwards compatible, and this game requires network play using The Argent Lark (impossible to reproduce using a local server), and The Argent Lark is anchored in 1.0.682 until next update.

Anyway, it would just work exactly the same as it works in current base, in this case, but if it was a larger changes set nobody would really know for sure. Use this as is a safest, _by the manual_ proceeding.