### PR TITLE
Trigger-death icon added to Rihn's Martyr's ability

### DIFF
--- a/data/cards-aether.cfg
+++ b/data/cards-aether.cfg
@@ -1053,6 +1053,7 @@ naught shall touch her chosen ones.",
                 triggered_abilities: [{
 				name: "Canonization ",
 				rules: "When Rihn's Martyr dies, an (Aether)&AElig;ther Monument Land is summoned in the lane she was in.",
+				icon: 'trigger-death.png',
 
 				on_die: "def(class creature creature, class game_state game) ->commands
 				if(game.is_loc_on_board(target_loc),


### PR DESCRIPTION
The icon changed to be more consistent with other cards which have abilities triggered by death.

It solves issue #208 – _More adecuate icon for the triggered ability of the Rihn's Martyr card_