### PR TITLE
Movement action in two phases for creatures with swift ability

### DIFF
--- a/data/classes/creature.cfg
+++ b/data/classes/creature.cfg
@@ -758,10 +758,7 @@ properties: {
 	
 	move_creature: "def(class game_state game, int nmoves) ->commands
 	if(can_move_not_blocked(game),
-		if(nmoves >= 2 and game.creature_at_loc([loc.x, loc.y + direction_moving*2]) = null,
-		   do_move_internal(game, 2, direction),
-		   do_move_internal(game, 1, direction)
-		)
+	   do_move_internal(game, 1, direction)
 	)
 	   where direction = direction_moving*sign(nmoves)
 	   where moves = abs(nmoves)


### PR DESCRIPTION
It works as I wrote in #242 issue.
But I must admit that a long arrow is little confusing when a creature moves  only one tile forward.