### PR TITLE
Update Divine Illumination spell.

### DIFF
--- a/data/cards-expansion_set-experimental_1.cfg
+++ b/data/cards-expansion_set-experimental_1.cfg
@@ -725,7 +725,7 @@ Devoted 5: Target creature gets Indestructible and an additional +2/+2 this turn
 		rules: "You gain 2 levels in other schools till the start of your next turn.",
 		flavor_text: "She saw it all through the vision, only to taste the sorrow about her own pettiness.",
 		on_play: "def(class game_state game, class message.play_card info) ->commands 
-					game.players[info.player].add_static_effect(
+					game.players[info.player_index].add_static_effect(
 						construct('static_effect', {
 							apply_fn:  def(class player player, map info)->commands [
 								add(player.base_resource_level[1], 2),


### PR DESCRIPTION
Should fix #254.

It looks like either at some point `info.player` might have
been synonymous for `info.player_index`, or this card could
have never worked OK. `info.player` is `null`, which is being
implicitly promoted to `0`, giving the mana bonus always to
player 0. This explains the misbehavior described by SkippyQ.
I actually checked that this change fixes the problem.