### PR TITLE
Disallow negative mana cost, e.g. from conduit

### DIFF
--- a/data/classes/player.cfg
+++ b/data/classes/player.cfg
@@ -284,9 +284,9 @@
 				static_cost_filters)",
 
 		calculate_cost_with_targets: "def(class game_state game, class card_base card, [Loc]|null targets) ->int
-		calculate_cost(card) +
+		max(0, calculate_cost(card) +
 		  if(land, land.modify_card_cost_targeted_at(card, player_index), 0) +
-		  if(creature, creature.modify_card_cost_targeted_at(card, player_index), 0)
+		  if(creature, creature.modify_card_cost_targeted_at(card, player_index), 0))
 
 		where land = if(targets, game.land_at_loc(targets[0]))
 		where creature = if(targets, game.creature_at_loc(targets[0]))


### PR DESCRIPTION
Prevent gaining mana by playing cards with negative modified cost, which make conduit far too powerful.